### PR TITLE
Fix view count API returns numeric totals

### DIFF
--- a/app/api/views/[slug]/route.tsx
+++ b/app/api/views/[slug]/route.tsx
@@ -13,7 +13,7 @@ export async function POST(
   
   return new Response(
     JSON.stringify({
-      total: (currentViews + 1).toString(),
+      total: currentViews + 1,
     }),
     { status: 200 }
   );
@@ -32,14 +32,14 @@ export async function GET(
     
     return new Response(
       JSON.stringify({
-        total: "0",
+        total: 0,
       }),
       { status: 200 }
     );
   } else {
     return new Response(
       JSON.stringify({
-        total: viewCount.toString(),
+        total: viewCount,
       }),
       { status: 200 }
     );


### PR DESCRIPTION
## Summary
- return numeric view counts from `app/api/views/[slug]/route.tsx`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ddae013083329a24c78d2e066c26