### PR TITLE
Update README paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ yarn dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
-You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.
+You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
-[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.ts`.
+[API routes](https://nextjs.org/docs/app/building-your-application/routing/route-handlers) can be accessed on [http://localhost:3000/api/projects](http://localhost:3000/api/projects). This endpoint can be edited in `app/api/projects/route.ts`.
 
-The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
+The `app/api` directory is mapped to `/api/*`. Files in this directory are treated as [Route Handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers) instead of React pages.
 
 ## Learn More
 


### PR DESCRIPTION
## Summary
- update README instructions for `app/page.tsx`
- update API route reference to an example under `app/api`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6845debaaa288332b80820926b0a4522