### PR TITLE
Add Vitest and initial test for blog posts

### DIFF
--- a/app/db/blog.test.ts
+++ b/app/db/blog.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { getBlogPosts } from './blog';
+import fs from 'fs';
+import path from 'path';
+
+describe('getBlogPosts', () => {
+  it('reads MDX files from the content directory and returns posts', () => {
+    const posts = getBlogPosts();
+    const files = fs
+      .readdirSync(path.join(process.cwd(), 'content'))
+      .filter((f) => path.extname(f) === '.mdx');
+
+    expect(Array.isArray(posts)).toBe(true);
+    expect(posts.length).toBe(files.length);
+
+    posts.forEach((post) => {
+      expect(post).toHaveProperty('metadata');
+      expect(post).toHaveProperty('slug');
+      expect(post).toHaveProperty('content');
+
+      expect(typeof post.slug).toBe('string');
+      expect(typeof post.content).toBe('string');
+      expect(typeof post.metadata).toBe('object');
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,8 @@
         "rehype": "13.0.2",
         "rehype-code-titles": "1.2.0",
         "rehype-slug": "6.0.0",
-        "typescript": "5.8.3"
+        "typescript": "5.8.3",
+        "vitest": "^1.5.0"
       },
       "engines": {
         "node": "20.x"
@@ -9348,6 +9349,10 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/vitest": {
+      "version": "1.5.0",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "npm run generate-prisma && next build",
     "generate-prisma": "prisma generate --schema ./prisma/schema.prisma",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest"
   },
   "dependencies": {
     "@prisma/client": "6.6.0",
@@ -41,6 +42,7 @@
     "rehype": "13.0.2",
     "rehype-code-titles": "1.2.0",
     "rehype-slug": "6.0.0",
-    "typescript": "5.8.3"
+    "typescript": "5.8.3",
+    "vitest": "^1.5.0"
   }
 }


### PR DESCRIPTION
## Summary
- add Vitest as a dev dependency and wire up `npm test`
- create `app/db/blog.test.ts` testing `getBlogPosts`

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845debc6e748332895da5f725cb72fe