### PR TITLE
🛡️ Sentinel: Add HTTP Security Headers

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,4 +4,37 @@
  */
 module.exports = {
   reactStrictMode: true,
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          },
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff',
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+          {
+            key: 'Permissions-Policy',
+            value: "camera=(), microphone=(), geolocation=()",
+          },
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=63072000; includeSubDomains; preload',
+          },
+          {
+            key: 'Content-Security-Policy',
+            value: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' va.vercel-scripts.com vitals.vercel-insights.com; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:; font-src 'self' data:; connect-src 'self' vitals.vercel-insights.com; frame-ancestors 'none';",
+          }
+        ],
+      },
+    ];
+  },
 };


### PR DESCRIPTION
🛡️ Sentinel: [Security Enhancement] Add HTTP Security Headers

**Enhancement:**
Added a comprehensive set of HTTP security headers to `next.config.js` to improve the application's defense-in-depth posture.

**Details:**
- **Content-Security-Policy (CSP):** Restricts sources for scripts, styles, images, and other resources. Explicitly allows Vercel Analytics (`va.vercel-scripts.com`, `vitals.vercel-insights.com`) and local resources (`'self'`). Blocks framing (`frame-ancestors 'none'`).
- **Strict-Transport-Security (HSTS):** Enforces HTTPS with a long max-age (2 years) and preload.
- **X-Frame-Options:** `DENY` to prevent clickjacking.
- **X-Content-Type-Options:** `nosniff` to prevent MIME type sniffing.
- **Referrer-Policy:** `strict-origin-when-cross-origin` to protect user privacy.
- **Permissions-Policy:** Disables sensitive features like camera, microphone, and geolocation by default.

**Verification:**
- Verified `next.config.js` syntax using `node -c`.
- Confirmed headers configuration matches Next.js documentation and Vercel Analytics requirements.

---
*PR created automatically by Jules for task [17702170148749965254](https://jules.google.com/task/17702170148749965254) started by @jreed91*