### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in JSON-LD script injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-14 - XSS in JSON-LD Script Injection
+**Vulnerability:** Cross-Site Scripting (XSS) vulnerability was found when injecting SEO metadata (JSON-LD) into a `<script type="application/ld+json">` tag using `dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}`.
+**Learning:** Directly stringifying JSON into HTML context does not escape specific HTML characters. An attacker controlling values inside the JSON-LD object (like a blog post title or description) could inject a malicious closing script tag `</script>` followed by their own script tag `<script>alert('XSS')</script>`, potentially leading to XSS if user-generated content or untrusted inputs are used to build the JSON string.
+**Prevention:** Implement a `safeJsonStringify` utility that replaces potentially dangerous characters (such as `<`, `>`, `&`, `\u2028`, `\u2029`) with their respective unicode escape sequences before injection.

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { getBlogPosts } from 'app/db/blog';
 import BlogLayout from '../../components/BlogLayout';
 import { notFound } from 'next/navigation';
 import { Metadata } from 'next';
+import { safeJsonStringify } from '../../utils/sanitize';
 
 const baseUrl = 'https://jacobreed.dev';
 
@@ -87,7 +88,7 @@ export default async function Blog({ params }: { params: Promise<{ slug: string 
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: safeJsonStringify(jsonLd) }}
       />
       <BlogLayout blog={post}>
       </BlogLayout>

--- a/app/utils/sanitize.ts
+++ b/app/utils/sanitize.ts
@@ -1,0 +1,8 @@
+export function safeJsonStringify(obj: any): string {
+  return JSON.stringify(obj)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Cross-Site Scripting (XSS) vulnerability found when injecting SEO metadata (JSON-LD) into a `<script type="application/ld+json">` tag using `dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}`. Directly stringifying JSON into an HTML context does not escape specific HTML characters, allowing potential injection of malicious closing script tags (`</script>`) followed by arbitrary scripts if user-controlled content is present.
🎯 **Impact:** An attacker could execute arbitrary JavaScript in the context of the user's browser, potentially leading to session hijacking, defacement, or redirection to malicious sites.
🔧 **Fix:** Implemented a `safeJsonStringify` utility (`app/utils/sanitize.ts`) that replaces potentially dangerous characters (`<`, `>`, `&`, `\u2028`, `\u2029`) with their respective unicode escape sequences before injection. Replaced the vulnerable `JSON.stringify` call in `app/blog/[slug]/page.tsx` with this new utility. Added an entry to `.jules/sentinel.md` documenting this finding.
✅ **Verification:** Verified by running `npm run lint`, `npm run test`, and `npm run build`. All checks passed, ensuring the application remains functional and secure.

---
*PR created automatically by Jules for task [331111397993678545](https://jules.google.com/task/331111397993678545) started by @jreed91*