### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS in iframe src from unvalidated videoUrl

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-05 - [Fix iframe src XSS]
+**Vulnerability:** XSS vulnerability via unsafe URI scheme in `iframe` `src` attribute.
+**Learning:** Unvalidated strings passed to `iframe` `src` attributes can be exploited if they contain `javascript:` or `data:` URIs. The `getYouTubeEmbedUrl` function returned the raw input if it wasn't a matching YouTube URL.
+**Prevention:** Always validate and sanitize URLs before passing them to sensitive DOM sinks like `iframe.src`, `a.href`, or `form.action`. Ensure they start with safe protocols like `http://` or `https://`.

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,12 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
+
+  // Security fix: Prevent XSS from javascript:, data:, and other unsafe URIs
+  // Ensure the fallback URL is safe before embedding it in an iframe.
+  if (videoUrl && !videoUrl.startsWith('http://') && !videoUrl.startsWith('https://')) {
+    return '';
+  }
+
   return videoUrl;
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: XSS via unsafe URI scheme in `iframe` `src` attribute. If a `videoUrl` in MDX frontmatter doesn't match the YouTube regex, the raw string is used as the fallback iframe `src`. This allows `javascript:` or `data:` URIs to execute arbitrary code.
🎯 Impact: Attackers could inject malicious scripts if they control the MDX frontmatter (e.g., via PR, compromised file, or CMS).
🔧 Fix: Validated that the fallback URL in `getYouTubeEmbedUrl` starts with `http://` or `https://`. If not, it returns an empty string.
✅ Verification: Ran `npm run test` and `npm run lint`. Tests pass. Verified that passing `javascript:alert(1)` to `getYouTubeEmbedUrl` now returns `''`. Added learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [17723037297283680293](https://jules.google.com/task/17723037297283680293) started by @jreed91*