### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in Talk iframes

### DIFF
--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,19 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('prevents XSS by rejecting javascript: URLs', () => {
+    const url = 'javascript:alert("XSS")';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('prevents XSS by rejecting data: URLs', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('rejects URLs missing a protocol entirely', () => {
+    const url = 'example.com/video';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,21 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Security: Prevent XSS by allowing only safe protocols for iframe src
+  const lowerUrl = videoUrl.toLowerCase();
+  if (lowerUrl.startsWith('http://') || lowerUrl.startsWith('https://')) {
+    return videoUrl;
+  }
+
+  // Return a safe fallback for invalid protocols like javascript: or data:
+  return 'about:blank';
 }


### PR DESCRIPTION
Fixes a potential XSS vulnerability in `TalkLayout.tsx` where an unvalidated `videoUrl` fallback from `getYouTubeEmbedUrl` was placed directly into an `iframe` `src`.

Enforces `http://` or `https://` validation for the fallback logic and defaults to `about:blank`. Tested against `javascript:` and `data:` URIs in `app/db/talks.test.ts`.

---
*PR created automatically by Jules for task [9683564116321187888](https://jules.google.com/task/9683564116321187888) started by @jreed91*