### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in YouTube embed URL fallback

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2024-05-18 - XSS Vulnerability in YouTube Embeds
+**Vulnerability:** The `getYouTubeEmbedUrl` function in `app/db/talks.ts` extracts a YouTube video ID using a regex. If the regex does not match, it returns the original `videoUrl` unchanged. This returned URL is then used directly as the `src` attribute of an `iframe` in `app/components/TalkLayout.tsx`. An attacker who can control the markdown frontmatter (or if it comes from an untrusted source) can set `videoUrl: 'javascript:alert(1)'` which bypasses the regex and gets injected directly into the iframe `src`, leading to Cross-Site Scripting (XSS).
+**Learning:** Fallback logic in URL parsers must enforce safe protocols (like `http:` or `https:`) before using the output in dangerous attributes like `href` or `src`. Returning the raw unvalidated string opens up XSS via `javascript:` or `data:` URIs.
+**Prevention:** If the URL does not match expected patterns, validate that it uses an allowed protocol before returning it, or return an empty string/safe default.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -30,7 +30,7 @@ describe('getYouTubeEmbedUrl', () => {
     );
   });
 
-  it('returns the original URL unchanged for non-YouTube URLs', () => {
+  it('returns the original URL unchanged for non-YouTube URLs if they are secure (HTTPS)', () => {
     const url = 'https://vimeo.com/123456789';
     expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
@@ -44,5 +44,15 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl(url)).toBe(
       'https://www.youtube.com/embed/abc-def_123'
     );
+  });
+
+  it('returns an empty string for dangerous protocols to prevent XSS', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('');
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('');
+    expect(getYouTubeEmbedUrl('vbscript:msgbox("hello")')).toBe('');
+  });
+
+  it('returns original URL for relative paths starting with /', () => {
+    expect(getYouTubeEmbedUrl('/local/video.mp4')).toBe('/local/video.mp4');
   });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,19 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Fallback: Validate that the URL uses a safe protocol to prevent XSS (e.g., javascript: or data:)
+  try {
+    const parsedUrl = new URL(videoUrl);
+    if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // If URL parsing fails (e.g., relative URL), optionally allow if it starts with '/'
+    if (videoUrl.startsWith('/')) {
+      return videoUrl;
+    }
+  }
+
+  return ''; // Return empty string for unsafe or invalid URLs
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Cross-Site Scripting (XSS) vulnerability in `getYouTubeEmbedUrl` fallback. When a video URL does not match the YouTube regex, it is returned unvalidated and injected directly into an `iframe` `src` attribute. 
🎯 Impact: An attacker who can control markdown frontmatter could set `videoUrl: 'javascript:alert(1)'`, executing arbitrary JavaScript when the user loads a talk page.
🔧 Fix: Added protocol validation in `getYouTubeEmbedUrl` to enforce safe protocols (`http:`, `https:`) or allow relative paths starting with `/`. Unsafe schemas return an empty string.
✅ Verification: Added test cases in `app/db/talks.test.ts` to confirm `javascript:`, `data:`, and `vbscript:` protocols return empty strings, preventing XSS payloads while keeping safe paths functional.
📓 Journal: Added critical learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [16236397028686570271](https://jules.google.com/task/16236397028686570271) started by @jreed91*