### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in video embed URLs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe XSS in getYouTubeEmbedUrl]
+**Vulnerability:** XSS vulnerability where `getYouTubeEmbedUrl` would blindly return an unmatched URL. If a user provided a `javascript:` or `data:` URL as the `videoUrl` in MDX frontmatter, it would be injected directly into the `src` attribute of the `iframe` in `TalkLayout`.
+**Learning:** Always validate that URLs used in sensitive attributes like `iframe src` or `a href` start with safe protocols (`http://`, `https://`, or `/`).
+**Prevention:** Implement an allowlist approach for URL protocols when falling back to user-provided input.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -39,6 +39,18 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl('')).toBe('');
   });
 
+  it('blocks javascript: URLs for security', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('');
+  });
+
+  it('blocks data: URLs for security', () => {
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('');
+  });
+
+  it('allows root-relative URLs', () => {
+    expect(getYouTubeEmbedUrl('/videos/local-talk.mp4')).toBe('/videos/local-talk.mp4');
+  });
+
   it('handles video IDs with hyphens and underscores', () => {
     const url = 'https://youtu.be/abc-def_123';
     expect(getYouTubeEmbedUrl(url)).toBe(

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,16 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
+
+  // Prevent XSS by allowing only safe protocols or absolute paths
+  if (
+    videoUrl &&
+    !videoUrl.startsWith('http://') &&
+    !videoUrl.startsWith('https://') &&
+    !videoUrl.startsWith('/')
+  ) {
+    return '';
+  }
+
   return videoUrl;
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `getYouTubeEmbedUrl` blindly returned an unmatched URL. If a user provided a `javascript:` or `data:` URL as the `videoUrl` in MDX frontmatter, it would be injected directly into the `src` attribute of the `iframe` in `TalkLayout`.
🎯 Impact: Attackers could execute arbitrary JavaScript within the application context via malicious MDX frontmatter values.
🔧 Fix: Implemented strict URL protocol validation in `getYouTubeEmbedUrl` to ensure fallback URLs begin with `http://`, `https://`, or `/`.
✅ Verification: Tests were updated to reflect the change, and `npm run test` verifies the vulnerability is patched.

---
*PR created automatically by Jules for task [5847195976796298818](https://jules.google.com/task/5847195976796298818) started by @jreed91*