### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in getYouTubeEmbedUrl

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-09 - [Fix XSS via iframe src]
+**Vulnerability:** XSS vulnerability in `getYouTubeEmbedUrl` inside `app/db/talks.ts` where the fallback URL for `iframe src` was not validated.
+**Learning:** If a `videoUrl` doesn't match the YouTube regex, returning it directly and rendering it in an `iframe` allows attackers to inject `javascript:` or `data:` URIs via MDX frontmatter, which execute arbitrary code.
+**Prevention:** Validate fallback URLs to ensure they only use safe protocols (`http://`, `https://`) or are relative paths (`/`). Reject all others by returning an empty string.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -39,6 +39,14 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl('')).toBe('');
   });
 
+  it('neutralizes dangerous javascript: URIs', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('');
+  });
+
+  it('neutralizes dangerous data: URIs', () => {
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('');
+  });
+
   it('handles video IDs with hyphens and underscores', () => {
     const url = 'https://youtu.be/abc-def_123';
     expect(getYouTubeEmbedUrl(url)).toBe(

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,15 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Security: Prevent XSS by allowing only safe protocols/paths for the fallback URL
+  if (
+    videoUrl.startsWith('http://') ||
+    videoUrl.startsWith('https://') ||
+    videoUrl.startsWith('/')
+  ) {
+    return videoUrl;
+  }
+
+  return '';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `getYouTubeEmbedUrl` function in `app/db/talks.ts` returns the `videoUrl` directly if it doesn't match the YouTube regex. This value is used directly in an `iframe` `src` attribute in `app/components/TalkLayout.tsx`. If a malicious `javascript:` or `data:` URI is provided via MDX frontmatter, it can lead to Cross-Site Scripting (XSS).
🎯 Impact: Attackers could potentially inject arbitrary code via MDX files if a malicious `javascript:` or `data:` URI is provided, leading to code execution when viewing a talk page.
🔧 Fix: Added protocol and path validation to `getYouTubeEmbedUrl`. It now only allows `http://`, `https://`, or paths starting with `/`. All other URLs (including `javascript:` and `data:`) return an empty string.
✅ Verification: Added unit tests explicitly checking for `javascript:` and `data:` URIs to ensure they return empty strings. Ran the test suite.

---
*PR created automatically by Jules for task [14604802376977724373](https://jules.google.com/task/14604802376977724373) started by @jreed91*