### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in Talk iframe URLs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix IFRAME src XSS]
+**Vulnerability:** XSS vulnerability where MDX frontmatter field `videoUrl` for a talk could contain arbitrary URIs (e.g. `javascript:alert(1)`). When this frontmatter is rendered into the `<iframe src={embedUrl}>` on the client, it would execute the javascript if the user's browser loaded the iframe or if it was otherwise triggered.
+**Learning:** React escapes HTML entities, but `src` or `href` attributes can still execute arbitrary code if they contain malicious URI schemes like `javascript:` or `data:`. Fallback values that use these attributes directly from user-input (or MDX files) must validate the protocol or at least sanitize the URI to safe schemes (`http(s)`) or relative paths.
+**Prevention:** Always ensure dynamically generated URIs used in `src` or `href` attributes are either whitelisted formats or strictly require `http://`, `https://`, or `/` relative paths to prevent URI-based XSS attacks.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,19 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('filters out dangerous javascript: URIs', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('');
+  });
+
+  it('filters out dangerous data: URIs', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('');
+  });
+
+  it('allows safe relative paths', () => {
+    const url = '/videos/local.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,12 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
+
+  // Security enhancement: Prevent XSS from javascript: or data: URIs
+  // Fall back to safe relative path or require http(s)
+  if (!videoUrl.startsWith('http://') && !videoUrl.startsWith('https://') && !videoUrl.startsWith('/')) {
+    return '';
+  }
+
   return videoUrl;
 }


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: The `getYouTubeEmbedUrl` function in `app/db/talks.ts` used a fallback to return the provided `videoUrl` directly if it wasn't a recognized YouTube URL. This meant any string supplied in the MDX `videoUrl` frontmatter field—including unsafe protocols like `javascript:` and `data:`—would be rendered directly into the `src` attribute of an `iframe` component (`TalkLayout.tsx`), leading to a Cross-Site Scripting (XSS) vulnerability.
🎯 **Impact**: If a malicious user controls the MDX content (e.g. via a PR or content upload), they could inject malicious Javascript payloads that execute in the context of the user viewing the talk.
🔧 **Fix**: Modified `getYouTubeEmbedUrl` to enforce an explicit allowlist pattern. Fallback URLs must now start with `http://`, `https://`, or `/`. Unsafe URIs are neutralized by returning an empty string. Added comprehensive unit tests to ensure `javascript:` and `data:` URIs are properly blocked.
✅ **Verification**: Run `npm run test` to verify the new test cases in `app/db/talks.test.ts` pass successfully.

---
*PR created automatically by Jules for task [7127546524832000138](https://jules.google.com/task/7127546524832000138) started by @jreed91*