### PR TITLE
🛡️ Sentinel: [HIGH] Fix iframe src XSS vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe src XSS]
+**Vulnerability:** XSS vulnerability where `getYouTubeEmbedUrl` returned the original `videoUrl` directly without validation if it didn't match the YouTube regex, allowing unsafe URIs like `javascript:alert(1)` to be injected into the `src` attribute of `<iframe>` elements in `app/components/TalkLayout.tsx`.
+**Learning:** `<iframe>` `src` attributes can execute arbitrary JavaScript if passed a `javascript:` URI. When accepting user-controlled input for an iframe source, failing to match a whitelist regex is not enough; the fallback behavior must also be safe.
+**Prevention:** When dynamically setting iframe `src` attributes or external link `href` attributes from unvalidated input, enforce `http://`, `https://`, or root-relative (`/`) protocols for fallback URLs, explicitly rejecting `javascript:`, `data:`, or `vbscript:` URIs.

--- a/app/components/TypewriterText.tsx
+++ b/app/components/TypewriterText.tsx
@@ -45,7 +45,11 @@ export default function TypewriterText() {
         );
         return () => clearTimeout(t);
       } else {
-        setState((s) => ({ ...s, isPaused: true }));
+        const t = setTimeout(
+          () => setState((s) => ({ ...s, isPaused: true })),
+          TYPE_SPEED
+        );
+        return () => clearTimeout(t);
       }
     } else {
       if (text.length > 0) {
@@ -56,11 +60,16 @@ export default function TypewriterText() {
         );
         return () => clearTimeout(t);
       } else {
-        setState((s) => ({
-          ...s,
-          isDeleting: false,
-          phraseIdx: (s.phraseIdx + 1) % ROLES.length,
-        }));
+        const t = setTimeout(
+          () =>
+            setState((s) => ({
+              ...s,
+              isDeleting: false,
+              phraseIdx: (s.phraseIdx + 1) % ROLES.length,
+            })),
+          DELETE_SPEED
+        );
+        return () => clearTimeout(t);
       }
     }
   }, [state]);

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,19 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns safe fallback for unsafe URLs (javascript:)', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('/');
+  });
+
+  it('returns safe fallback for unsafe URLs (data:)', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('/');
+  });
+
+  it('returns original URL for safe root-relative paths', () => {
+    const url = '/local-video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,11 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
+
+  // Fallback: prevent XSS by rejecting javascript:, data:, vbscript: etc.
+  if (videoUrl && !/^(?:https?:\/\/|\/)/i.test(videoUrl)) {
+    return '/'; // Safe fallback
+  }
+
   return videoUrl;
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `getYouTubeEmbedUrl` returned unvalidated strings that didn't match the YouTube regex, allowing malicious users to inject unsafe `javascript:` or `data:` URIs directly into the `src` attribute of `<iframe>` elements.
🎯 Impact: This could execute arbitrary Javascript if unvalidated user input was passed as a `videoUrl` for a talk, resulting in Cross-Site Scripting (XSS).
🔧 Fix: Enforced safe fallback protocols. If a string doesn't match the YouTube regex, it is validated to ensure it starts with `http://`, `https://`, or `/`. Otherwise, it falls back to a safe `/` path.
✅ Verification: Run `npm test` to verify the new test cases testing `javascript:` and `data:` URIs.

*(Also fixed an unrelated cascading renders issue due to synchronous `setState` inside `useEffect` in `app/components/TypewriterText.tsx` which was causing `npm run lint` to fail).*

---
*PR created automatically by Jules for task [9840691325482562318](https://jules.google.com/task/9840691325482562318) started by @jreed91*