### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in talks iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-14 - [XSS via Unsafe iframe src]
+**Vulnerability:** The `getYouTubeEmbedUrl` function in `app/db/talks.ts` returned `videoUrl` directly if it didn't match the YouTube regex, allowing MDX authors to potentially inject unsafe protocols like `javascript:` or `data:` into the `iframe` `src` attribute in `app/components/TalkLayout.tsx`.
+**Learning:** User-provided URLs (or markdown frontmatter URLs) used in `href` or `src` attributes must always be validated against an allowlist of safe protocols (`http:`, `https:`) or verified as relative paths. Falling back to an empty string `""` on error can cause iframe recursive loading; returning `"about:blank"` is safer.
+**Prevention:** Use `new URL(url, "http://localhost")` to safely parse URLs and check `url.protocol` against `["http:", "https:"]`, explicitly handling root-relative paths. Return `about:blank` for invalid URLs.

--- a/app/components/TypewriterText.tsx
+++ b/app/components/TypewriterText.tsx
@@ -45,7 +45,8 @@ export default function TypewriterText() {
         );
         return () => clearTimeout(t);
       } else {
-        setState((s) => ({ ...s, isPaused: true }));
+        const t = setTimeout(() => setState((s) => ({ ...s, isPaused: true })), 0);
+        return () => clearTimeout(t);
       }
     } else {
       if (text.length > 0) {
@@ -56,11 +57,12 @@ export default function TypewriterText() {
         );
         return () => clearTimeout(t);
       } else {
-        setState((s) => ({
+        const t = setTimeout(() => setState((s) => ({
           ...s,
           isDeleting: false,
           phraseIdx: (s.phraseIdx + 1) % ROLES.length,
-        }));
+        })), 0);
+        return () => clearTimeout(t);
       }
     }
   }, [state]);

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -30,13 +30,13 @@ describe('getYouTubeEmbedUrl', () => {
     );
   });
 
-  it('returns the original URL unchanged for non-YouTube URLs', () => {
+  it('returns the original URL unchanged for non-YouTube URLs with http/https', () => {
     const url = 'https://vimeo.com/123456789';
     expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 
-  it('returns the original URL unchanged for empty string', () => {
-    expect(getYouTubeEmbedUrl('')).toBe('');
+  it('returns about:blank for empty string', () => {
+    expect(getYouTubeEmbedUrl('')).toBe('about:blank');
   });
 
   it('handles video IDs with hyphens and underscores', () => {
@@ -44,5 +44,20 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl(url)).toBe(
       'https://www.youtube.com/embed/abc-def_123'
     );
+  });
+
+  it('returns about:blank for javascript: protocol', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for data: protocol', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns the original URL unchanged for root-relative paths', () => {
+    const url = '/local-video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,18 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Fallback: Validate protocol to prevent XSS (e.g., javascript:, data:)
+  try {
+    if (!videoUrl) return 'about:blank';
+
+    const url = new URL(videoUrl, 'http://localhost'); // Provide a base for relative URLs
+    if (['http:', 'https:'].includes(url.protocol) || videoUrl.startsWith('/')) {
+      return videoUrl;
+    }
+  } catch (e) {
+    // If URL parsing fails, fall back to safe default
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `getYouTubeEmbedUrl` function in `app/db/talks.ts` was returning the raw `videoUrl` unchanged if it didn't match a YouTube URL regex. This allowed authors to potentially inject unsafe URIs like `javascript:` or `data:` into the `<iframe src>` attribute in `app/components/TalkLayout.tsx`.
🎯 **Impact:** If malicious frontmatter was injected into a talk MDX file, an attacker could achieve Cross-Site Scripting (XSS) or execute arbitrary code when the talk page is viewed.
🔧 **Fix:** Added strict protocol validation to `getYouTubeEmbedUrl`. It now parses the fallback URL and explicitly allows only `http:`, `https:`, or root-relative paths (`/`). Unsafe protocols or invalid URLs safely fallback to `'about:blank'`.
✅ **Verification:** Verified fix by running the test suite (`npm run test`) which now explicitly tests against `javascript:` and `data:` protocols, ensuring they return `about:blank`. Additionally fixed an unrelated ESLint warning (`react-hooks/set-state-in-effect`) in `TypewriterText.tsx` to ensure `npm run lint` passes completely.

---
*PR created automatically by Jules for task [943337688776765358](https://jules.google.com/task/943337688776765358) started by @jreed91*