### PR TITLE
🛡️ Sentinel: [security improvement] Add Content-Security-Policy header

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -31,6 +31,10 @@ module.exports = {
           {
             key: 'Permissions-Policy',
             value: 'camera=(), microphone=(), geolocation=()'
+          },
+          {
+            key: 'Content-Security-Policy',
+            value: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; frame-src 'self' https://www.youtube.com; upgrade-insecure-requests;"
           }
         ]
       }


### PR DESCRIPTION
🛡️ Sentinel: [security improvement] Add Content-Security-Policy header

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The application previously lacked a `Content-Security-Policy` header in `next.config.js`. While other security headers like `X-Frame-Options` and `Permissions-Policy` were present, the absence of a CSP left the application with a defense-in-depth weakness against cross-site scripting (XSS) and data injection attacks.
🎯 **Impact:** An attacker who successfully found an injection point could potentially load external malicious scripts, framing the application maliciously, or embedding unsafe objects.
🔧 **Fix:** Added a solid `Content-Security-Policy` header to `next.config.js`. The policy specifically:
* Restricts default, font, and base-uri sources to `'self'`.
* Restricts scripts and styles to `'self'` and `'unsafe-inline'` / `'unsafe-eval'` (needed for Next.js routing and styling).
* Prevents embedding the site (`frame-ancestors 'none'`) beyond the legacy `X-Frame-Options`.
* Restricts `frame-src` to `'self'` and `https://www.youtube.com` (to support embedded talks).
* Blocks `<object>` and `<embed>` entirely.
* Requires `upgrade-insecure-requests`.
✅ **Verification:** Verified by running `npm run build` and the full `vitest` test suite. The header is correctly configured in the `headers` array of the Next.js config.

---
*PR created automatically by Jules for task [8850701821935073427](https://jules.google.com/task/8850701821935073427) started by @jreed91*