### PR TITLE
🛡️ Sentinel: [HIGH] Sanitize iframe URLs to prevent XSS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix XSS via unsafe iframe src]
+**Vulnerability:** XSS vulnerability where non-YouTube URLs from `videoUrl` in talk frontmatter were passed directly to an `iframe`'s `src` attribute. If an attacker injects `javascript:alert(1)` into the `videoUrl`, it executes within the application when viewed.
+**Learning:** `iframe` `src` attributes are susceptible to `javascript:` and `data:` URI attacks. Any dynamic content placed into an `iframe src` must be validated to ensure it uses a safe protocol (e.g., `http://`, `https://`) or is a relative path.
+**Prevention:** Sanitize dynamically generated or user-provided fallback URLs used in `iframe src` by enforcing protocol whitelists (only allowing `http://`, `https://`, or `/`) and falling back to `about:blank`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -39,6 +39,21 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl('')).toBe('');
   });
 
+  it('returns about:blank for unsafe URL schemes like javascript:', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for unsafe URL schemes like data:', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('allows root-relative URLs', () => {
+    const url = '/static/video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
+
   it('handles video IDs with hyphens and underscores', () => {
     const url = 'https://youtu.be/abc-def_123';
     expect(getYouTubeEmbedUrl(url)).toBe(

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,17 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
+
+  // 🛡️ Sentinel: Prevent XSS by validating the protocol of fallback URLs
+  // Only allow http://, https://, or root-relative paths for iframe src
+  if (
+    videoUrl &&
+    !videoUrl.startsWith('http://') &&
+    !videoUrl.startsWith('https://') &&
+    !videoUrl.startsWith('/')
+  ) {
+    return 'about:blank';
+  }
+
   return videoUrl;
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Potential XSS vulnerability where non-YouTube fallback URLs from the `videoUrl` frontmatter of talks were placed directly into the `src` attribute of an `iframe` component (`app/components/TalkLayout.tsx`). If an attacker could modify the frontmatter to inject a `javascript:` or `data:` URL, this could lead to the execution of malicious scripts.
🎯 Impact: An attacker could execute arbitrary JavaScript within the application context, potentially stealing session cookies, performing actions on behalf of the user, or defacing the application.
🔧 Fix: Updated `getYouTubeEmbedUrl` in `app/db/talks.ts` to strictly validate the protocol of the provided fallback URL. It now allows only `http://`, `https://`, or root-relative paths starting with `/`. If the URL does not meet these criteria, it securely falls back to `about:blank`. Also added robust unit tests covering these unsafe URI scenarios.
✅ Verification: Ensure tests pass via `npm run test` (or `npx vitest run`) and specifically examine `app/db/talks.test.ts` to confirm XSS scenarios are securely blocked.

---
*PR created automatically by Jules for task [11680114627291324225](https://jules.google.com/task/11680114627291324225) started by @jreed91*