### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in TalkLayout iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe src XSS in Talks]
+**Vulnerability:** XSS vulnerability where `videoUrl` derived from MDX frontmatter was rendered directly into an `iframe`'s `src` attribute without protocol validation in `app/components/TalkLayout.tsx`.
+**Learning:** Even though `iframe` tags are generally thought of for embedding, malicious `javascript:` or `data:` URIs in the `src` attribute can execute arbitrary code in the context of the page if the iframe lacks a restrictive `sandbox` attribute. Content derived from local Markdown files still needs sanitization if it specifies executable attributes.
+**Prevention:** Always enforce safe protocol validation (`http://`, `https://`, or root-relative paths starting with `/`) for dynamically populated `href` or `src` attributes. Fall back to a safe default like `about:blank` for invalid URLs.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,17 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for javascript: URIs to prevent XSS', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('returns about:blank for data: URIs to prevent XSS', () => {
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
+  });
+
+  it('allows root-relative paths', () => {
+    const url = '/videos/local-talk.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,23 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Prevent XSS by allowing only safe protocols or root-relative paths
+  if (
+    videoUrl.startsWith('http://') ||
+    videoUrl.startsWith('https://') ||
+    videoUrl.startsWith('/')
+  ) {
+    return videoUrl;
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `videoUrl` derived from MDX frontmatter was rendered directly into an `iframe`'s `src` attribute without protocol validation in `app/components/TalkLayout.tsx`.
🎯 Impact: This allows malicious `javascript:` or `data:` URIs to execute arbitrary code within the page context when a Talk is viewed. While the data source is currently local MDX files, content from local sources still needs sanitization if it specifies executable attributes, serving as defense-in-depth against unauthorized modifications or if the content source is later dynamic.
🔧 Fix: Updated `getYouTubeEmbedUrl` in `app/db/talks.ts` to strictly validate protocols (`http://`, `https://`, or root-relative `/`) and fall back to `about:blank`.
✅ Verification: Ran unit tests and all pass, including new cases for safe protocols and blocking `javascript:` / `data:` URIs.

Also recorded learning in `.jules/sentinel.md` per Sentinel protocols.

---
*PR created automatically by Jules for task [14656027440063969489](https://jules.google.com/task/14656027440063969489) started by @jreed91*