### PR TITLE
🛡️ Sentinel: [HIGH] Sanitize YouTube embed fallback URLs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2026-03-18 - [Fix XSS via Unsafe iframe SRC in Talks]
+**Vulnerability:** XSS vulnerability where `getYouTubeEmbedUrl` would return arbitrary strings directly to an `iframe src` if the string didn't match a YouTube URL. This allows malicious MDX frontmatter to inject `javascript:` or `data:` URIs into the iframe.
+**Learning:** Fallback return values for URL processing functions must still enforce basic protocol validation (`http://`, `https://`, or root-relative `/`). Even if user input is intended to be a benign URL, any field that eventually sets an `href` or `src` is an XSS vector if not validated.
+**Prevention:** Always validate that URLs constructed from unsanitized sources use safe protocols. If a URL is invalid or unsafe, fallback to `about:blank` or an empty string, rather than returning the input unchanged.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -39,6 +39,17 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl('')).toBe('');
   });
 
+  it('returns about:blank for dangerous or unapproved schemes', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('vbscript:msgbox(1)')).toBe('about:blank');
+  });
+
+  it('allows root-relative fallback paths', () => {
+    const url = '/videos/local-talk.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
+
   it('handles video IDs with hyphens and underscores', () => {
     const url = 'https://youtu.be/abc-def_123';
     expect(getYouTubeEmbedUrl(url)).toBe(

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,17 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Fallback validation: only allow http/https or root-relative paths
+  if (
+    videoUrl &&
+    (videoUrl.startsWith('http://') ||
+      videoUrl.startsWith('https://') ||
+      videoUrl.startsWith('/'))
+  ) {
+    return videoUrl;
+  }
+
+  // Prevent javascript:, data:, and other unsafe URIs from being embedded
+  return videoUrl ? 'about:blank' : '';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `getYouTubeEmbedUrl` returned unmodified arbitrary strings directly to `iframe src` if the string didn't match a YouTube URL. This allowed malicious MDX frontmatter to inject `javascript:` or `data:` URIs into the iframe.
🎯 Impact: High risk of XSS if a user embeds malicious video URLs via the CMS or Markdown files.
🔧 Fix: Updated `getYouTubeEmbedUrl` to enforce basic protocol validation (`http://`, `https://`, or `/`). Fallbacks to `about:blank` for invalid/unsafe URLs. Added robust unit tests to verify the fix.
✅ Verification: Ran unit tests via `npx vitest run app/db/talks.test.ts`. All test cases verify XSS vectors like `javascript:alert(1)` are safely converted to `about:blank`.

---
*PR created automatically by Jules for task [12361517163441527678](https://jules.google.com/task/12361517163441527678) started by @jreed91*