### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in YouTube embed URL fallback

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix MDX Frontmatter VideoUrl XSS]
+**Vulnerability:** XSS vulnerability where untrusted `videoUrl` strings from MDX frontmatter were directly injected into `<iframe> src` attributes via `getYouTubeEmbedUrl` in `app/db/talks.ts`.
+**Learning:** If a URL failed a strict YouTube regex check, it was blindly returned as a fallback string. This allowed malicious `javascript:alert(1)` or `data:` URIs placed inside MDX frontmatter to bypass protections and trigger JavaScript execution when a user loads a Talk page.
+**Prevention:** Always validate external URL inputs using the `URL` constructor or protocol checks. Ensure fallback URLs start with `http://`, `https://`, or `/`, and reject insecure protocols like `javascript:` and `data:`. Use `about:blank` as a safe fallback when URL parsing fails or protocols are invalid.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,19 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('prevents XSS by rejecting javascript: URIs', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('prevents XSS by rejecting data: URIs', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('allows root-relative URLs as fallback', () => {
+    const url = '/static/video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,27 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Security enhancement: Prevent XSS by validating the protocol
+  // Only allow http://, https://, or root-relative paths
+  try {
+    const parsedUrl = new URL(videoUrl, 'http://localhost');
+    if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+      if (videoUrl.startsWith('/') || videoUrl.startsWith('http')) {
+        return videoUrl;
+      }
+    }
+  } catch (e) {
+    // If URL parsing fails, fall through to the safe default
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH

💡 **Vulnerability:** The `getYouTubeEmbedUrl` helper in `app/db/talks.ts` was returning raw strings if they didn't match the expected YouTube formats. This allowed attackers to craft an MDX file with a `videoUrl` set to an unsafe URI scheme such as `javascript:alert(1)`. This string was then injected directly into the `src` attribute of the iframe in `app/components/TalkLayout.tsx`, creating an XSS risk.

🎯 **Impact:** Attackers who can control MDX content (e.g. via PR or shared repositories) could execute arbitrary JavaScript in the context of the user viewing the talk page.

🔧 **Fix:** 
- Updated `getYouTubeEmbedUrl` to enforce protocol validation. If a string is not a valid YouTube URL, we check that it uses `http:`, `https:`, or is a root-relative path (e.g., starts with `/`).
- If parsing fails or the protocol is forbidden (like `javascript:` or `data:`), we return a safe `about:blank` fallback.
- Added comprehensive Vitest cases to assert that XSS vectors are blocked and legitimate fallbacks remain permitted.

✅ **Verification:** Run `npm test` to ensure all `app/db/talks.test.ts` scenarios (including `javascript:` and `data:` rejections) pass without regression.

---
*PR created automatically by Jules for task [4763445694337427463](https://jules.google.com/task/4763445694337427463) started by @jreed91*