### PR TITLE
🛡️ Sentinel: [HIGH] Fix iframe src XSS vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2026-03-20 - [Fix iframe src XSS]
+**Vulnerability:** XSS vulnerability where untrusted user input from MDX frontmatter (`videoUrl`) was used directly as the fallback URL in an `iframe` `src` attribute. If an attacker provided a `javascript:` or `data:` URI, the iframe could execute malicious scripts.
+**Learning:** `iframe` `src` attributes are sensitive to XSS just like `a` `href` attributes. Dynamic URLs must be validated to ensure they use safe protocols.
+**Prevention:** Always parse untrusted URLs and validate their protocol (`http:` or `https:`). If falling back, allow explicitly safe patterns (e.g., root-relative paths starting with `/`) or default to `about:blank`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,16 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('neutralizes javascript: URIs to prevent XSS', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('neutralizes data: URIs to prevent XSS', () => {
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
+  });
+
+  it('preserves root-relative URLs', () => {
+    expect(getYouTubeEmbedUrl('/videos/my-talk.mp4')).toBe('/videos/my-talk.mp4');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,30 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Security enhancement: Prevent XSS by validating the protocol of fallback URLs
+  // Allow root-relative URLs
+  if (videoUrl.startsWith('/')) {
+    return videoUrl;
+  }
+
+  try {
+    const url = new URL(videoUrl);
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // If it can't be parsed as a valid URL (and didn't match our relative checks)
+    // we drop through to about:blank
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unsanitized user input from MDX frontmatter (`videoUrl`) was used directly as the fallback URL in an `iframe` `src` attribute. This allowed for `javascript:` or `data:` URIs to be injected, leading to potential Cross-Site Scripting (XSS).
🎯 **Impact:** If an attacker (or compromised MDX content) provided a malicious `javascript:` URI, the iframe would execute arbitrary code when rendered on the Talk layout page.
🔧 **Fix:** Updated the fallback logic in `getYouTubeEmbedUrl` to validate the protocol of the URL. Only explicit `http:`, `https:`, and root-relative paths starting with `/` are permitted. All other invalid or unsafe schemas default to `about:blank` to fail securely.
✅ **Verification:** Added comprehensive unit tests in `app/db/talks.test.ts` to verify that `javascript:` and `data:` schemas are neutralized, while standard protocols and root-relative paths remain preserved. Run `npm run test` and `npm run lint` to verify.

---
*PR created automatically by Jules for task [8611185263239279241](https://jules.google.com/task/8611185263239279241) started by @jreed91*