### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe src for talks

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2026-03-21 - [XSS via iframe src in Talks]
+**Vulnerability:** XSS vulnerability through `javascript:` or `data:` URIs in the `iframe` `src` attribute. This was possible because the `getYouTubeEmbedUrl` function returned non-YouTube URLs exactly as provided.
+**Learning:** Returning user-controlled URLs as-is into `iframe` `src` (or similar active attributes) can allow arbitrary JavaScript execution if the input is a malicious URI like `javascript:alert(1)`.
+**Prevention:** Always parse and validate URL protocols (`http:` or `https:`) before injecting them into HTML attributes such as `src` or `href`. For internal/relative routes, explicitly verify they begin with `/`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,22 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for javascript: URLs (XSS protection)', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('returns about:blank for data: URLs (XSS protection)', () => {
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe(
+      'about:blank'
+    );
+  });
+
+  it('returns about:blank for invalid URLs', () => {
+    expect(getYouTubeEmbedUrl('invalid-url')).toBe('about:blank');
+  });
+
+  it('returns the original URL for valid relative paths', () => {
+    expect(getYouTubeEmbedUrl('/local-video.mp4')).toBe('/local-video.mp4');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,25 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return videoUrl;
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
+
+  try {
+    const parsed = new URL(videoUrl);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return 'about:blank';
+    }
+  } catch {
+    if (!videoUrl.startsWith('/')) {
+      return 'about:blank';
+    }
+  }
+
   return videoUrl;
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Cross-Site Scripting (XSS) vulnerability was identified in `app/db/talks.ts` where `getYouTubeEmbedUrl` returned unmodified non-YouTube URLs. This could allow an attacker to inject malicious `javascript:` or `data:` URIs into the `<iframe src={...}>` tag in `app/components/TalkLayout.tsx`.
🎯 Impact: If malicious content enters the MDX metadata, it could lead to arbitrary JavaScript execution in the user's browser, leading to session hijacking, defacement, or other attacks.
🔧 Fix: Updated `getYouTubeEmbedUrl` to parse the given URL using the `URL` constructor and validate its protocol. If the protocol is not `http:` or `https:` and it is not a valid relative path starting with `/`, it falls back securely to `about:blank`. Added tests to cover these safety scenarios.
✅ Verification: Ensure tests pass via `npx vitest run`. Test coverage validates XSS prevention for `javascript:` and `data:` URIs.

---
*PR created automatically by Jules for task [3868305845744224155](https://jules.google.com/task/3868305845744224155) started by @jreed91*