### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-21 - [Fix Iframe Src XSS]
+**Vulnerability:** XSS vulnerability where user-provided URLs in `app/db/talks.ts` were passed unmodified to an `iframe` `src` attribute in `app/components/TalkLayout.tsx` if they didn't match a YouTube URL regex.
+**Learning:** `iframe` `src` attributes are vulnerable to `javascript:` and `data:` URIs. If an attacker controls the data (e.g. via frontmatter or database input), they can execute arbitrary JavaScript in the context of the page by providing a `javascript:` URL.
+**Prevention:** Always validate protocols for URLs dynamically injected into `iframe` `src` attributes or external links. Only allow `http://`, `https://`, or root-relative `/` URLs, and fallback to `about:blank` for invalid inputs.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -35,8 +35,23 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 
-  it('returns the original URL unchanged for empty string', () => {
-    expect(getYouTubeEmbedUrl('')).toBe('');
+  it('blocks javascript: URIs', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('blocks data: URIs', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('allows root-relative URLs', () => {
+    const url = '/static/video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
+
+  it('returns about:blank for empty string', () => {
+    expect(getYouTubeEmbedUrl('')).toBe('about:blank');
   });
 
   it('handles video IDs with hyphens and underscores', () => {

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,15 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Sanitize non-YouTube URLs to prevent XSS in iframe src
+  if (
+    videoUrl.startsWith('http://') ||
+    videoUrl.startsWith('https://') ||
+    videoUrl.startsWith('/')
+  ) {
+    return videoUrl;
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `app/db/talks.ts` does not validate protocols when returning URLs that don't match YouTube patterns. The resulting URLs are injected unmodified into the `<iframe src="...">` attribute in `app/components/TalkLayout.tsx`. This could allow an attacker to use `javascript:` or `data:` URIs via the talks MDX frontmatter to execute arbitrary JavaScript in the context of the page.
🎯 Impact: An attacker could perform malicious actions, steal cookies, or trick users by running an XSS payload.
🔧 Fix: Updated the `getYouTubeEmbedUrl` function to check that non-YouTube URLs start with either `http://`, `https://`, or `/`. All other URLs fall back safely to `about:blank`. Updated corresponding tests to verify these checks.
✅ Verification: Ran unit tests with Vitest, generated a local visual check using Playwright to confirm `javascript:` protocols render an empty fallback frame, and passed ESLint checks.

---
*PR created automatically by Jules for task [980559913297537175](https://jules.google.com/task/980559913297537175) started by @jreed91*