### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in talks iframe

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix XSS in TalkLayout Video iframe]
+**Vulnerability:** XSS vulnerability where `videoUrl` sourced from MDX frontmatter was directly placed in the `src` attribute of an `iframe` component within `TalkLayout.tsx` via `getYouTubeEmbedUrl` when it was not a match for YouTube URL logic.
+**Learning:** Any user-controlled (or in this case, markdown frontmatter-controlled) URL rendered in an `iframe` or `a` tag `src`/`href` must be validated against dangerous protocols like `javascript:` or `data:`, otherwise attackers can execute arbitrary JS via URLs.
+**Prevention:** In `getYouTubeEmbedUrl`, validate URLs to ensure they use allowed protocols (`http://`, `https://`) or are root-relative (`/`) paths before returning them; otherwise fallback to safe URLs like `'about:blank'`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,26 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('neutralizes XSS payloads with javascript: URIs', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('neutralizes XSS payloads with data: URIs', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('allows http:// and https:// URLs that are not YouTube', () => {
+    const urlHttp = 'http://example.com/video.mp4';
+    const urlHttps = 'https://example.com/video.mp4';
+    expect(getYouTubeEmbedUrl(urlHttp)).toBe(urlHttp);
+    expect(getYouTubeEmbedUrl(urlHttps)).toBe(urlHttps);
+  });
+
+  it('allows root-relative paths', () => {
+    const url = '/local-videos/my-talk.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,24 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Prevent XSS via unsafe URIs (like javascript: or data:)
+  // Enforce http://, https://, or root-relative paths
+  if (
+    videoUrl.startsWith('http://') ||
+    videoUrl.startsWith('https://') ||
+    videoUrl.startsWith('/')
+  ) {
+    return videoUrl;
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in talks iframe

🚨 Severity: HIGH
💡 Vulnerability: `getYouTubeEmbedUrl` allowed unsafe URLs (`javascript:`, `data:`) to be returned and directly used as the `src` attribute for an `iframe` in `TalkLayout`. This could allow arbitrary JavaScript execution if malicious data was passed through MDX frontmatter.
🎯 Impact: An attacker could inject an XSS payload, compromising user sessions and security context.
🔧 Fix: Updated `getYouTubeEmbedUrl` to enforce safe protocols (`http://`, `https://`) or root-relative paths (`/`), returning `'about:blank'` for any other type of URL, thereby neutralizing unsafe `javascript:` and `data:` URIs.
✅ Verification: Ran unit tests which include specific coverage for XSS payloads on iframe `src`, all tests passed. Validated linting passes.

---
*PR created automatically by Jules for task [17438792623696452451](https://jules.google.com/task/17438792623696452451) started by @jreed91*