### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS via unsafe iframe src in TalkLayout

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe XSS via unsafe video URLs]
+**Vulnerability:** XSS vulnerability where unvalidated `videoUrl` fields from MDX frontmatter were injected directly into an `iframe`'s `src` attribute in `app/components/TalkLayout.tsx`.
+**Learning:** Next.js and React do not automatically validate `src` attributes of `iframes`. Attackers could use `javascript:` or `data:` URIs in the frontmatter `videoUrl` to bypass the YouTube regex and achieve arbitrary script execution when the iframe renders.
+**Prevention:** Always validate external URLs to enforce safe protocols (`http://` or `https://`) or allow root-relative paths. If validation fails, provide a safe fallback like `about:blank` instead of returning the original unsafe user input.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,19 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('blocks javascript: URIs', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('blocks data: URIs', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('allows root-relative URLs', () => {
+    const url = '/videos/talk.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe('/videos/talk.mp4');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,24 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Fallback to about:blank to prevent XSS via javascript: or data: URIs
+  // if the URL doesn't use a safe protocol.
+  if (
+    videoUrl.startsWith('http://') ||
+    videoUrl.startsWith('https://') ||
+    videoUrl.startsWith('/')
+  ) {
+    return videoUrl;
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `app/components/TalkLayout.tsx` used unvalidated `videoUrl` directly as an `iframe src` when rendering talk videos. Attackers could supply a `javascript:` or `data:` URI (e.g., `javascript:alert(1)`) in MDX frontmatter to achieve arbitrary script execution.
🎯 Impact: High - Cross-Site Scripting (XSS) allowing for arbitrary code execution in the browser context if an attacker could control MDX files.
🔧 Fix: Updated `getYouTubeEmbedUrl` in `app/db/talks.ts` to strictly enforce that fallback URLs use safe protocols (`http://`, `https://`) or are relative paths (`/`). Malicious inputs now safely fallback to `about:blank`.
✅ Verification: Tested against existing cases, `javascript:` payload, `data:` payload, and relative URL. Tests successfully pass via `npm run test`.

---
*PR created automatically by Jules for task [17239447845303639411](https://jules.google.com/task/17239447845303639411) started by @jreed91*