### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in Talk iframe source

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2023-10-27 - [Fix iframe src XSS]
+**Vulnerability:** XSS vulnerability where unsafe protocols (`javascript:`, `data:`, `vbscript:`) could be passed via the `videoUrl` frontmatter field of a Talk and directly injected into the `src` attribute of an `iframe` component.
+**Learning:** `iframe src` attributes evaluate JavaScript when `javascript:` protocols are used. Validating or sanitizing external URLs supplied through Markdown metadata is critical, even when they're not explicitly `dangerouslySetInnerHTML`. Relying strictly on Next.js/React component properties doesn't protect against `src` exploits.
+**Prevention:** Always validate URLs meant for `iframe src`, `a href`, or similar sensitive attributes to ensure they use allowed protocols (`http://`, `https://`) or are valid root-relative paths. Fall back to safe defaults like `about:blank` for invalid or unsafe URLs.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,19 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('neutralizes unsafe javascript: URLs', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('neutralizes unsafe data: URLs', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('allows safe relative URLs', () => {
+    const url = '/static/video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,28 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Security: Prevent XSS via unsafe protocols (javascript:, data:, vbscript:)
+  // Only allow http://, https://, or root-relative URLs
+  try {
+    const parsedUrl = new URL(videoUrl, 'http://dummy.com'); // Base helps parse relative URLs
+
+    // If it's a relative URL starting with '/', or an allowed protocol, return it
+    if (videoUrl.startsWith('/') || parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // URL parsing failed
+  }
+
+  // Fall back to a safe empty page to prevent execution
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: XSS vulnerability where unsafe protocols (`javascript:`, `data:`, `vbscript:`) could be passed via the `videoUrl` frontmatter field of a Talk and directly injected into the `src` attribute of an `iframe` component.
🎯 Impact: Attackers could potentially execute arbitrary JavaScript in the context of the user's browser by crafting a malicious Markdown file or injecting malicious metadata.
🔧 Fix: Updated `getYouTubeEmbedUrl` in `app/db/talks.ts` to strictly validate that URLs use safe protocols (`http:`, `https:`) or are valid root-relative paths. If not, it falls back to `about:blank`.
✅ Verification: Added comprehensive unit tests in `app/db/talks.test.ts` to ensure malicious protocols are neutralized and safe ones are permitted. All tests pass successfully.

---
*PR created automatically by Jules for task [9718675067950064798](https://jules.google.com/task/9718675067950064798) started by @jreed91*