### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS in YouTube embed fallback URL

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2024-05-20 - Unsafe Protocol URIs in Fallback URLs allow XSS
+**Vulnerability:** XSS vulnerability where user-supplied URLs (from frontmatter like `videoUrl` fallback in `app/db/talks.ts`) were passed unsanitized into an iframe `src` attribute. Unsafe URIs like `javascript:alert(1)` could execute arbitrary code.
+**Learning:** `iframe` elements, just like `a` and `form` actions, are susceptible to protocol-based XSS if the injected string is not validated to start with standard `http://`, `https://`, or relative `/` routes.
+**Prevention:** Always validate that URLs originating from external inputs (or MDX metadata fallback) start with safe prefixes (e.g. `http://` or `https://` or `/`). Otherwise, force the value to `about:blank`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -35,7 +35,7 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 
-  it('returns the original URL unchanged for empty string', () => {
+  it('returns an empty string for empty string', () => {
     expect(getYouTubeEmbedUrl('')).toBe('');
   });
 
@@ -44,5 +44,17 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl(url)).toBe(
       'https://www.youtube.com/embed/abc-def_123'
     );
+  });
+
+  it('returns about:blank for unsafe protocols (XSS prevention)', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('vbscript:msgbox(1)')).toBe('about:blank');
+  });
+
+  it('allows http:// and https:// and root-relative / paths', () => {
+    expect(getYouTubeEmbedUrl('http://example.com/video.mp4')).toBe('http://example.com/video.mp4');
+    expect(getYouTubeEmbedUrl('https://example.com/video.mp4')).toBe('https://example.com/video.mp4');
+    expect(getYouTubeEmbedUrl('/local/video.mp4')).toBe('/local/video.mp4');
   });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,22 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Prevent XSS by allowing only safe protocols or root-relative paths
+  if (
+    videoUrl.startsWith('http://') ||
+    videoUrl.startsWith('https://') ||
+    videoUrl.startsWith('/')
+  ) {
+    return videoUrl;
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: Unsanitized fallback URLs for YouTube videos could allow attackers to inject malicious `javascript:` or `data:` URIs into iframe `src` attributes, leading to Cross-Site Scripting (XSS).
🎯 **Impact**: An attacker who can control frontmatter data (e.g., via a PR) could execute arbitrary JavaScript in the context of the user's browser viewing the talk.
🔧 **Fix**: Enforced protocol validation (`http://`, `https://`, or root-relative `/`) on the fallback URL in `app/db/talks.ts`. Any non-compliant URL is now forced to `about:blank`.
✅ **Verification**: Run `npm run test` to verify the new test cases in `app/db/talks.test.ts` that specifically check for `javascript:alert(1)` returning `about:blank`.

---
*PR created automatically by Jules for task [2599287451731348357](https://jules.google.com/task/2599287451731348357) started by @jreed91*