### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix iframe XSS vulnerability in talks module

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe XSS]
+**Vulnerability:** XSS vulnerability where user-supplied URLs (from MDX frontmatter) were injected directly into the `src` attribute of `iframe` tags without protocol validation in `app/components/TalkLayout.tsx` (via `getYouTubeEmbedUrl`).
+**Learning:** `iframe` `src` attributes are susceptible to execution of arbitrary JavaScript via `javascript:` URIs or loading malicious content via `data:` URIs. Relying solely on a regex to convert specific YouTube URLs is not sufficient if the fallback is to return the raw input.
+**Prevention:** Always validate protocols for user-supplied URLs used in `src` or `href` attributes. Ensure they are explicitly `http:`, `https:`, or safe root-relative paths, and fallback to `about:blank` for invalid or unsafe URIs.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,19 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for javascript: URIs (XSS protection)', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for data: URIs (XSS protection)', () => {
+    const url = 'data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('allows root-relative paths', () => {
+    const url = '/local-video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,24 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const parsedUrl = new URL(videoUrl, 'http://localhost');
+    if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch {
+    // URL parsing failed
+  }
+
+  // Prevent XSS from javascript:, data: or other unsafe URIs in iframes
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: User-supplied `videoUrl` values from MDX frontmatter were injected directly into the `src` attribute of `iframe` tags in `app/components/TalkLayout.tsx` without protocol validation if they did not match the YouTube regex pattern.
🎯 Impact: Attackers or malicious authors could input a `javascript:alert(1)` or `data:text/html,...` URI, resulting in Cross-Site Scripting (XSS) when the iframe loaded.
🔧 Fix: Updated `getYouTubeEmbedUrl` in `app/db/talks.ts` to parse the URL. If it falls back from the YouTube regex, it enforces `http:` or `https:` protocols (which safely handles root-relative paths via a dummy local base url). Unsafe payloads now return `about:blank`.
✅ Verification: Added tests to `app/db/talks.test.ts` ensuring `javascript:` and `data:` protocols resolve to `about:blank`, while standard links function correctly. Run `npx vitest run` to verify. A journal entry was logged in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [10107695236223595211](https://jules.google.com/task/10107695236223595211) started by @jreed91*