### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe URI

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix XSS via unsafe Iframe URI]
+**Vulnerability:** XSS vulnerability where `getYouTubeEmbedUrl` would return arbitrary strings for unrecognized URLs, allowing `javascript:` or `data:` URIs to be passed to an `iframe`'s `src` attribute.
+**Learning:** Returning unvalidated fallback URLs for external links or iframes is unsafe, as `iframe` elements can execute scripts if given `javascript:` URIs, leading to XSS if the source (like MDX frontmatter) is compromised or untrusted.
+**Prevention:** Always enforce strict protocol validation (e.g. `http://`, `https://`, or root-relative `/`) on URLs before using them in DOM elements that load resources or navigate, falling back to a safe URI like `about:blank`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,19 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('blocks javascript: URIs to prevent XSS', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('blocks data: URIs to prevent XSS', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('allows relative URLs starting with /', () => {
+    const url = '/static/videos/my-video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,23 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return videoUrl;
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Security: block unsafe URIs (e.g. javascript:, data:) to prevent XSS
+  if (
+    videoUrl.startsWith('http://') ||
+    videoUrl.startsWith('https://') ||
+    videoUrl.startsWith('/')
+  ) {
+    return videoUrl;
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe URI

🚨 **Severity:** HIGH
💡 **Vulnerability:** `getYouTubeEmbedUrl` previously returned unvalidated arbitrary strings if they did not match the expected YouTube format. This value was directly injected into the `src` attribute of an `iframe` element in `app/components/TalkLayout.tsx`. If an attacker provided a `javascript:` or `data:` URI (e.g. via compromised or untrusted MDX frontmatter), they could achieve Cross-Site Scripting (XSS).
🎯 **Impact:** Attackers could execute arbitrary JavaScript within the application context, leading to session hijacking, unauthorized actions, or data theft.
🔧 **Fix:** Updated `getYouTubeEmbedUrl` to enforce strict protocol validation. If the URL is not a recognized YouTube format, it verifies that the string begins with `http://`, `https://`, or `/`. If none of these match, it securely falls back to `about:blank`.
✅ **Verification:** Added dedicated test cases in `app/db/talks.test.ts` to verify protocol validation blocks `javascript:` and `data:` URIs, while permitting standard relative links. Executed `npx vitest run` successfully and confirmed all 45 tests pass. Recorded critical learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [14896334290348884254](https://jules.google.com/task/14896334290348884254) started by @jreed91*