### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in video embed URLs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix XSS via video embed URL in iframe]
+**Vulnerability:** XSS vulnerability where `getYouTubeEmbedUrl` would blindly return an unsanitized video URL, which is placed inside an iframe's `src` attribute. This allowed `javascript:alert(1)` to be executed if a malicious user updated the markdown's `videoUrl`.
+**Learning:** Iframes can execute JavaScript code if their `src` attribute is set to `javascript:...`. Furthermore, using `data:text/html,...` can run arbitrary code or render anything. You must enforce that the URLs originate from a safe protocol (e.g., `http://` or `https://`) or are an absolute path.
+**Prevention:** Always sanitize dynamically constructed iframe URLs by testing if they start with `http://`, `https://`, or `/`. Fall back to `about:blank` or block the render entirely.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,19 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('blocks javascript: URLs to prevent XSS in iframe', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('blocks data: URLs to prevent XSS in iframe', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('allows absolute paths', () => {
+    const url = '/local-video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe('/local-video.mp4');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,6 +62,12 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  // 🛡️ Sentinel: XSS protection
+  // Ensure the URL is an HTTP/HTTPS URL or an absolute path before returning.
+  // If not, fall back to about:blank to prevent javascript: or data: execution in iframe
+  const isSafeUrl = /^(https?:\/\/|\/)/i.test(videoUrl);
+  if (!videoUrl) return '';
+  if (!isSafeUrl) return 'about:blank';
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `getYouTubeEmbedUrl` would blindly return an unsanitized video URL, which is placed inside an iframe's `src` attribute. This allowed `javascript:alert(1)` to be executed if a malicious user updated the markdown's `videoUrl`.
🎯 Impact: An attacker could execute arbitrary JavaScript code via iframe XSS if they manipulated the video URL.
🔧 Fix: Updated `getYouTubeEmbedUrl` to explicitly check and enforce that the URL is an allowed protocol (`http://`, `https://`) or an absolute path (`/`). It falls back to `about:blank`. Also added unit tests to confirm prevention.
✅ Verification: Ran unit tests and all pass.

---
*PR created automatically by Jules for task [16095107106673848486](https://jules.google.com/task/16095107106673848486) started by @jreed91*