### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS in TalkLayout iframe

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-31 - [Fix XSS via malicious iframe src in TalkLayout]
+**Vulnerability:** XSS vulnerability in `getYouTubeEmbedUrl` in `app/db/talks.ts` allowing malicious URIs (e.g., `javascript:`, `data:`) in MDX frontmatter to be injected into an `iframe`'s `src` attribute.
+**Learning:** Returning user-provided fallback URLs unmodified opens the door to XSS attacks via iframe source injection if the URL protocol is not validated.
+**Prevention:** Always validate protocols of fallback URLs (e.g., enforcing `http://`, `https://`, or relative paths starting with `/`) and return a safe fallback like `about:blank` for invalid inputs.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,19 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for javascript: URIs', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for data: URIs', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns original URL for relative paths', () => {
+    const url = '/videos/local-talk.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,15 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  if (
+    !videoUrl ||
+    videoUrl.startsWith('/') ||
+    videoUrl.startsWith('http://') ||
+    videoUrl.startsWith('https://')
+  ) {
+    return videoUrl;
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `getYouTubeEmbedUrl` in `app/db/talks.ts` returns the unvalidated `videoUrl` directly if it doesn't match the YouTube regex. This allows malicious URIs (e.g., `javascript:`, `data:`) sourced from MDX frontmatter to be injected into the `src` attribute of the `iframe` in `app/components/TalkLayout.tsx`.
🎯 Impact: Attackers could potentially achieve Cross-Site Scripting (XSS) or execute arbitrary code if they can inject a malicious `videoUrl` into the talk's metadata.
🔧 Fix: Updated `getYouTubeEmbedUrl` to enforce a strict allowlist of URL protocols (`http://`, `https://`) or root-relative paths (`/`). Any unvalidated string falls back to `about:blank`.
✅ Verification: Added tests for `getYouTubeEmbedUrl` in `app/db/talks.test.ts` to assert that `javascript:` and `data:` URIs return `about:blank` and ran `npm run test` successfully.

---
*PR created automatically by Jules for task [2731884861015052740](https://jules.google.com/task/2731884861015052740) started by @jreed91*