### PR TITLE
🛡️ Sentinel: [HIGH] Fix iframe src XSS vulnerability with protocol allowlist

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2026-04-02 - [Iframe SRC XSS Prevention]
+**Vulnerability:** XSS vulnerability through iframe `src` attributes where an attacker could provide `javascript:` or `data:` URLs via MDX frontmatter (e.g., `videoUrl` fallback in `getYouTubeEmbedUrl`).
+**Learning:** Iframes and links directly sourced from markdown frontmatter are not automatically sanitized by React. Unsafe protocols can execute arbitrary JavaScript in the context of the user's browser.
+**Prevention:** Enforce strict allowlists for protocols (e.g., `http://`, `https://`, or root-relative `/`). Fallback to `about:blank` if the source does not conform to safe protocols.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,19 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for javascript: URLs (XSS Prevention)', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for data: URLs (XSS Prevention)', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('preserves valid root-relative paths', () => {
+    const url = '/local-video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,17 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
+
+  // XSS Prevention: Enforce safe protocols for iframes
+  if (!videoUrl) return '';
+  const isSafeUrl =
+    videoUrl.startsWith('http://') ||
+    videoUrl.startsWith('https://') ||
+    videoUrl.startsWith('/');
+
+  if (!isSafeUrl) {
+    return 'about:blank';
+  }
+
   return videoUrl;
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** XSS vulnerability through iframe `src` attributes where an attacker could provide `javascript:` or `data:` URLs via MDX frontmatter (`videoUrl` fallback in `getYouTubeEmbedUrl`). React does not automatically sanitize `src` attributes of `iframe` elements.
🎯 **Impact:** If an attacker can control the frontmatter content (or if malicious content is processed), they could execute arbitrary JavaScript in the context of the user's browser by injecting `javascript:alert('XSS')` into the `videoUrl`.
🔧 **Fix:** Added a strict protocol allowlist in `getYouTubeEmbedUrl`. The function now enforces that the returned URL must start with `http://`, `https://`, or `/`. If an unsafe protocol is provided, it falls back to `about:blank`.
✅ **Verification:** Verified by running the test suite (`npm run test`). Added specific unit tests in `app/db/talks.test.ts` to verify `javascript:` and `data:` protocols are blocked, while valid root-relative paths and secure protocols are permitted.

---
*PR created automatically by Jules for task [6631368387288388496](https://jules.google.com/task/6631368387288388496) started by @jreed91*