### PR TITLE
🛡️ Sentinel: [HIGH] Fix iframe XSS via data/javascript URLs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe XSS via data/javascript URLs]
+**Vulnerability:** XSS vulnerability where user-supplied `videoUrl` values from MDX frontmatter are placed directly into `iframe src` attributes in `app/components/TalkLayout.tsx` without validating the protocol.
+**Learning:** `iframe` `src` attributes can execute arbitrary JavaScript if supplied with a `javascript:` or `data:` URL. This allows XSS if an attacker controls or injects values into the MDX frontmatter.
+**Prevention:** Always validate protocols of dynamically inserted URLs used in `href` or `src` attributes. Only allow `http:`, `https:`, and root-relative (`/`) paths. Fallback to `about:blank` for invalid inputs.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,19 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for javascript: URLs', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for data: URLs', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('allows relative URLs', () => {
+    const url = '/some/video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,16 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  if (!videoUrl) return '';
+
+  if (
+    videoUrl.startsWith('http://') ||
+    videoUrl.startsWith('https://') ||
+    videoUrl.startsWith('/')
+  ) {
+    return videoUrl;
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unsanitized user-supplied `videoUrl` values from MDX frontmatter were placed directly into `iframe src` attributes in `app/components/TalkLayout.tsx` without protocol validation, allowing arbitrary JavaScript execution via `javascript:` or `data:` URLs.
🎯 **Impact:** XSS if an attacker controls or injects values into the MDX frontmatter.
🔧 **Fix:** Added protocol validation to `getYouTubeEmbedUrl` in `app/db/talks.ts`. It now only allows `http://`, `https://`, and root-relative (`/`) paths for non-YouTube URLs. Invalid inputs fallback to `about:blank`.
✅ **Verification:** Run `npm run test` to verify the new test cases in `app/db/talks.test.ts` pass, specifically checking that `javascript:` and `data:` URLs are sanitized.

---
*PR created automatically by Jules for task [173932928641366274](https://jules.google.com/task/173932928641366274) started by @jreed91*