### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe src attribute

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe src XSS in Talk Layout]
+**Vulnerability:** XSS vulnerability in `app/db/talks.ts` where unvalidated external fallback URLs could be used as an iframe `src` attribute in `app/components/TalkLayout.tsx`. If a user specifies a `javascript:` or `data:` URI, it could lead to script execution.
+**Learning:** Content that populates `iframe src` attributes must be validated against a whitelist of safe protocols. Unvalidated input falling through to the `src` attribute is dangerous.
+**Prevention:** Always validate and enforce `http://`, `https://`, or root-relative (`/`) prefixes for user-controlled fallback URLs that populate iframe or link locations, defaulting to `about:blank` for safe failure.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -30,7 +30,7 @@ describe('getYouTubeEmbedUrl', () => {
     );
   });
 
-  it('returns the original URL unchanged for non-YouTube URLs', () => {
+  it('returns the original URL unchanged for non-YouTube URLs with safe protocols', () => {
     const url = 'https://vimeo.com/123456789';
     expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
@@ -44,5 +44,16 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl(url)).toBe(
       'https://www.youtube.com/embed/abc-def_123'
     );
+  });
+
+  it('returns about:blank for unsafe protocols to prevent XSS', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('vbscript:msgbox("hello")')).toBe('about:blank');
+  });
+
+  it('returns the original URL unchanged for root-relative paths', () => {
+    const url = '/videos/local-video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,23 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Ensure fallback URLs enforce safe protocols to prevent XSS via javascript: or data: URIs.
+  if (
+    videoUrl.startsWith('http://') ||
+    videoUrl.startsWith('https://') ||
+    videoUrl.startsWith('/')
+  ) {
+    return videoUrl;
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** XSS vulnerability in `app/db/talks.ts` where unvalidated external fallback URLs could be rendered in an iframe `src` attribute in `app/components/TalkLayout.tsx`.
🎯 **Impact:** If an attacker can inject a payload like `javascript:alert('XSS')` into the `videoUrl` frontmatter of a talk's MDX file, the `<iframe src="...">` would execute arbitrary code.
🔧 **Fix:** Added protocol validation inside `getYouTubeEmbedUrl` to enforce an allowlist of safe prefixes (`http://`, `https://`, or root-relative `/`). If the fallback URL does not match these, it fails safely by returning `about:blank`.
✅ **Verification:** Updated tests in `app/db/talks.test.ts` pass, ensuring `javascript:` and `data:` URIs are properly blocked. Evaluated via `npm run test` which confirms the fix.

---
*PR created automatically by Jules for task [7931437646500168428](https://jules.google.com/task/7931437646500168428) started by @jreed91*