### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS in iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe src XSS]
+**Vulnerability:** XSS vulnerability in `getYouTubeEmbedUrl` where an unrecognized URL in talk frontmatter was passed unsanitized directly to an iframe's `src` attribute.
+**Learning:** Iframes and links parsing user/metadata URLs can execute XSS if an attacker inputs a `javascript:` or `data:` URI.
+**Prevention:** Always validate and sanitize fallback URIs dynamically passed to `href` or `src` attributes. Require safe protocols (`http://`, `https://`) or relative paths (`/`), and fallback to a safe default like `about:blank`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -35,8 +35,16 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 
-  it('returns the original URL unchanged for empty string', () => {
-    expect(getYouTubeEmbedUrl('')).toBe('');
+  it('returns about:blank for empty string', () => {
+    expect(getYouTubeEmbedUrl('')).toBe('about:blank');
+  });
+
+  it('returns about:blank for unsafe javascript: protocol', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('returns about:blank for unsafe data: protocol', () => {
+    expect(getYouTubeEmbedUrl('data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTs8L3NjcmlwdD4=')).toBe('about:blank');
   });
 
   it('handles video IDs with hyphens and underscores', () => {

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,10 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Prevent XSS by validating the fallback URL protocol
+  if (videoUrl.startsWith('http://') || videoUrl.startsWith('https://') || videoUrl.startsWith('/')) {
+    return videoUrl;
+  }
+  return 'about:blank';
 }


### PR DESCRIPTION
*   🚨 Severity: HIGH
*   💡 Vulnerability: `videoUrl` from frontmatter in MDX could pass an unsanitized URL (e.g. `javascript:alert('XSS')`) directly to an iframe's `src` attribute.
*   🎯 Impact: If malicious content enters the frontmatter (e.g., via user submission or a compromised MDX file), visiting the talk page could execute arbitrary JS in the user's browser.
*   🔧 Fix: Enforced protocol validation (`http://`, `https://`, `/`) in `getYouTubeEmbedUrl`, returning `about:blank` for invalid/unsafe schemes.
*   ✅ Verification: Verified fix via `npm run test` and new vitest unit tests specifically checking for `javascript:` and `data:` protocol rejection.

---
*PR created automatically by Jules for task [4380432054004519424](https://jules.google.com/task/4380432054004519424) started by @jreed91*