### PR TITLE
🛡️ Sentinel: [HIGH] Fix iframe src XSS vulnerability in TalkLayout

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+## 2025-03-03 - [Fix iframe src XSS]
+**Vulnerability:** XSS/SSRF vulnerability where frontmatter data (such as `videoUrl` in talks) could contain arbitrary protocols (`javascript:`, `data:`, `vbscript:`, `file:`) and was directly bound to the `src` attribute of an `iframe`.
+**Learning:** `iframe` `src` attributes without protocol validation allow executing JavaScript or accessing local resources if an attacker modifies the input metadata. Next.js/React does not sanitize URI protocols for `src` by default.
+**Prevention:** Validate protocols and ensure the provided URL starts with HTTP, HTTPS, or a safe local path. If the URL contains an unsafe protocol or is an empty string, always return `'about:blank'`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -30,13 +30,13 @@ describe('getYouTubeEmbedUrl', () => {
     );
   });
 
-  it('returns the original URL unchanged for non-YouTube URLs', () => {
+  it('returns the original URL unchanged for safe non-YouTube URLs', () => {
     const url = 'https://vimeo.com/123456789';
     expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 
-  it('returns the original URL unchanged for empty string', () => {
-    expect(getYouTubeEmbedUrl('')).toBe('');
+  it('returns about:blank for empty string', () => {
+    expect(getYouTubeEmbedUrl('')).toBe('about:blank');
   });
 
   it('handles video IDs with hyphens and underscores', () => {
@@ -44,5 +44,20 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl(url)).toBe(
       'https://www.youtube.com/embed/abc-def_123'
     );
+  });
+
+  it('prevents XSS by returning about:blank for unsafe protocols', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('prevents XSS by returning about:blank for data URIs', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('allows root-relative URLs', () => {
+    const url = '/videos/local-talk.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,23 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return 'about:blank';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
+
+  try {
+    const parsedUrl = new URL(videoUrl, 'http://localhost');
+    if (['javascript:', 'data:', 'vbscript:', 'file:'].includes(parsedUrl.protocol)) {
+      return 'about:blank';
+    }
+  } catch (e) {
+    return 'about:blank';
+  }
+
   return videoUrl;
 }


### PR DESCRIPTION
🚨 **Severity**: HIGH

💡 **Vulnerability**: A potential Cross-Site Scripting (XSS) / Server-Side Request Forgery (SSRF) vector was found in `app/db/talks.ts` and `app/components/TalkLayout.tsx`. Specifically, user-controlled frontmatter data (e.g., `videoUrl`) lacked validation for unsafe URI protocols before being directly injected as the `src` attribute of a React `iframe`.

🎯 **Impact**: If an attacker manipulated the content metadata (e.g., by exploiting a separate vulnerability or if frontmatter is dynamically populated), they could assign protocols like `javascript:` or `data:`, leading to arbitrary JavaScript execution in the context of the user's session.

🔧 **Fix**: Updated the `getYouTubeEmbedUrl` function in `app/db/talks.ts` to utilize the native `URL` constructor (coupled with a safe baseline host) to reliably extract and validate the `.protocol` property. Unsafe protocols (`javascript:`, `data:`, `vbscript:`, `file:`) and empty strings now strictly return `'about:blank'`.

✅ **Verification**: Run `npx vitest run app/db/talks.test.ts` to ensure all 10 tests cleanly pass, explicitly checking against XSS injection cases and confirming regular and valid relative URLs are properly allowed.

---
*PR created automatically by Jules for task [7735897286367694204](https://jules.google.com/task/7735897286367694204) started by @jreed91*