### PR TITLE
🛡️ Sentinel: [HIGH] Fix iframe XSS vulnerability in video URLs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2026-04-07 - [Secure URL Validation for iFrames]
+**Vulnerability:** XSS vulnerability via unsafe URL protocols (e.g., `javascript:`, `data:`) used directly in dynamic `iframe` `src` attributes within `app/db/talks.ts` and `app/components/TalkLayout.tsx`.
+**Learning:** Returning user-provided or unverified URLs (like fallback `videoUrl`) directly into an `iframe src` without protocol validation allows arbitrary script execution if the URL uses `javascript:`. Simple regex checks (like for YouTube) are insufficient if the fallback is a raw return of the input.
+**Prevention:** Always validate protocols using the native `URL` constructor (e.g., `new URL(url, 'http://localhost')`) and strictly enforce safe protocols (`http:`, `https:`) before assigning to `iframe src` or similar sensitive DOM sink attributes. Default to `about:blank` for invalid inputs.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,19 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for javascript: URIs (XSS protection)', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for data: URIs (XSS protection)', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns the original URL for valid root-relative paths', () => {
+    const url = '/local/video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,23 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const url = new URL(videoUrl, 'http://localhost');
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // ignore parsing errors
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `getYouTubeEmbedUrl` function returned fallback URLs unmodified if they didn't match the YouTube regex. This allowed untrusted `javascript:` or `data:` URIs to be directly embedded in an `iframe`'s `src` attribute, exposing an XSS vector.
🎯 Impact: An attacker could potentially inject malicious scripts through manipulated video URL metadata, executing arbitrary code in the context of the user's session.
🔧 Fix: Updated the logic to validate non-YouTube URLs using the native `URL` constructor, strictly enforcing `http:` or `https:` protocols. Invalid protocols safely default to `about:blank`.
✅ Verification: New tests were added to `app/db/talks.test.ts` to explicitly verify XSS payloads are neutralized. All test cases (`npm run test`) pass cleanly.

---
*PR created automatically by Jules for task [4343030920260477621](https://jules.google.com/task/4343030920260477621) started by @jreed91*