### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS via unsafe protocols in iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2024-04-08 - [Prevent XSS in dynamically generated iframe sources]
+**Vulnerability:** The `getYouTubeEmbedUrl` function in `app/db/talks.ts` used a frontmatter URL (`videoUrl`) as a fallback value directly in an iframe's `src` attribute. This could lead to Cross-Site Scripting (XSS) if an unsafe protocol like `javascript:` or `data:` was provided.
+**Learning:** Even if an input is expected to be a YouTube embed URL, fallbacks passed to sensitive contexts (like `iframe` `src`) must strictly validate protocols to block execution of potentially malicious payload.
+**Prevention:** Always parse untrusted or fallback URLs (e.g. using `new URL(url, 'http://localhost')`) and strictly enforce safe protocols (`http:`, `https:`) or specific safe relative paths before embedding them in an iframe.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,17 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for javascript: URLs to prevent XSS', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('  javascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('returns about:blank for data: URLs to prevent XSS', () => {
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
+  });
+
+  it('allows root-relative URLs', () => {
+    expect(getYouTubeEmbedUrl('/my-video.mp4')).toBe('/my-video.mp4');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,23 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const url = new URL(videoUrl, 'http://localhost');
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (error) {
+    // Ignore invalid URLs
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `getYouTubeEmbedUrl` fell back to returning an unvalidated URL which was directly used in an iframe `src` attribute. If an unsafe protocol like `javascript:` or `data:` was provided (e.g. from user input or corrupted markdown), it would lead to XSS execution.
🎯 Impact: Attackers could execute arbitrary code within the user's browser via a malicious `videoUrl` payload.
🔧 Fix: Used the native `URL` constructor to enforce safe protocols (`http:`, `https:`) for any fallback URL, defaulting to `about:blank` for unsafe payloads. This maintains functionality for root-relative paths when resolving against a dummy local base.
✅ Verification: New unit tests were added to `app/db/talks.test.ts` to assert that `javascript:` and `data:` URLs are safely rejected, and all 45 vitest tests pass successfully.

---
*PR created automatically by Jules for task [6914730504615319050](https://jules.google.com/task/6914730504615319050) started by @jreed91*