### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix iframe src XSS in getYouTubeEmbedUrl

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2024-04-09 - [iframe src XSS Vulnerability via Fallback Protocol Validation]
+**Vulnerability:** XSS/SSRF via unsanitized `videoUrl` directly injected into `iframe` `src` attribute. When MDX frontmatter `videoUrl` was not a YouTube URL, the application returned the URL unchanged, allowing `javascript:` or `data:` URIs to execute arbitrary code in `app/components/TalkLayout.tsx`.
+**Learning:** React escapes content but NOT attribute values like `href` or `src` containing malicious URI schemes. Fallback URLs extracted from user input or frontmatter MUST be strictly protocol-validated before injection into risky elements (`iframe`, `a`, `object`, etc.).
+**Prevention:** Implement strict URI protocol validation checking for `http:` or `https:`. Use `new URL(url, 'http://localhost')` for robust extraction and check `.protocol`. Explicitly deny protocol-relative URIs (`//...`) if unintended. Return a safe fallback like `about:blank`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -39,6 +39,26 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl('')).toBe('');
   });
 
+  it('returns about:blank for javascript: URIs', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for data: URIs', () => {
+    const url = 'data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('allows root-relative URLs', () => {
+    const url = '/my-video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
+
+  it('returns about:blank for protocol-relative URLs (prevent SSRF/XSS)', () => {
+    const url = '//malicious.com/video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
   it('handles video IDs with hyphens and underscores', () => {
     const url = 'https://youtu.be/abc-def_123';
     expect(getYouTubeEmbedUrl(url)).toBe(

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,32 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Prevent protocol-relative URLs from being treated as http/https by the URL constructor relative fallback
+  if (videoUrl.startsWith('//')) {
+    return 'about:blank';
+  }
+
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch {
+    // Ignore invalid URLs
+  }
+
+  if (videoUrl.startsWith('/') && !videoUrl.startsWith('//')) {
+    return videoUrl;
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: When an MDX file provided a non-YouTube URL in `videoUrl` frontmatter, the original URL was directly injected into the `iframe` `src` attribute. This allowed XSS/SSRF payloads like `javascript:alert(1)` or `data:` URIs to execute arbitrary code within the page's origin.
🎯 Impact: Attackers could gain full control over the session or perform actions on behalf of the user if they managed to inject a malicious URL into the frontmatter or if the metadata was somehow user-controlled or compromised.
🔧 Fix: Added strict protocol validation to `getYouTubeEmbedUrl` using the native `URL` constructor to enforce `http:` or `https:`. Explicitly disabled protocol-relative (`//`) URLs to prevent SSRF bypasses. Falls back securely to `about:blank` for invalid or malicious inputs.
✅ Verification: Tested via vitest (`npm run test`) explicitly checking `javascript:`, `data:`, root-relative, and protocol-relative URIs, and recorded the mitigation in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [8350717711393502965](https://jules.google.com/task/8350717711393502965) started by @jreed91*