### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in TalkLayout via unsafe iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2026-04-10 - [Fix XSS via iframe src URI Fallback]
+**Vulnerability:** XSS vulnerability where `getYouTubeEmbedUrl` in `app/db/talks.ts` blindly returned non-YouTube strings unmodified, which were then used as the `src` attribute of an `iframe` in `app/components/TalkLayout.tsx`. This allowed arbitrary JS execution via `javascript:` URIs provided in MDX frontmatter.
+**Learning:** Returning unvalidated fallbacks for URLs used in active DOM contexts like `iframe src` or `a href` creates XSS vectors. Simple string matching is insufficient for protocol validation since whitespace padding (e.g. `   javascript:`) can bypass it.
+**Prevention:** Always parse and validate URIs before rendering them in sensitive attributes. Use the native `URL` constructor with a dummy base (e.g., `new URL(uri, 'http://localhost')`) to reliably extract and validate the `.protocol` property against a strict allowlist (like `http:` and `https:`), and fail securely by falling back to `about:blank`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -35,8 +35,8 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 
-  it('returns the original URL unchanged for empty string', () => {
-    expect(getYouTubeEmbedUrl('')).toBe('');
+  it('returns about:blank for empty string', () => {
+    expect(getYouTubeEmbedUrl('')).toBe('about:blank');
   });
 
   it('handles video IDs with hyphens and underscores', () => {
@@ -44,5 +44,18 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl(url)).toBe(
       'https://www.youtube.com/embed/abc-def_123'
     );
+  });
+
+  it('returns about:blank for javascript: URIs', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('   javascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('returns about:blank for data: URIs', () => {
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
+  });
+
+  it('allows root-relative URLs by validating as http://localhost fallback', () => {
+    expect(getYouTubeEmbedUrl('/local-video.mp4')).toBe('/local-video.mp4');
   });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,23 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return 'about:blank';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Security: prevent XSS via unsafe protocols in iframe src
+  try {
+    const url = new URL(videoUrl, 'http://localhost');
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URLs
+  }
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `getYouTubeEmbedUrl` in `app/db/talks.ts` blindly returned non-YouTube fallback strings unmodified. When these strings were bound to the `src` attribute of an `iframe` in `app/components/TalkLayout.tsx`, it allowed attackers to execute arbitrary JavaScript using `javascript:` or `data:` URIs provided in the MDX frontmatter.
🎯 Impact: An attacker who can influence MDX frontmatter could trigger a Cross-Site Scripting (XSS) payload that runs in the context of the user visiting the page.
🔧 Fix: Updated the `getYouTubeEmbedUrl` function to enforce protocol validation. Using the native `new URL()` constructor with a localhost base, it checks the extracted `.protocol`. If the protocol is not `http:` or `https:`, it safely falls back to `about:blank`.
✅ Verification: Added comprehensive unit tests in `app/db/talks.test.ts` verifying that `javascript:`, padded `javascript:`, and `data:` URIs evaluate to `about:blank`, while allowing normal URLs and relative paths. Tests successfully pass.

---
*PR created automatically by Jules for task [16870416462764235046](https://jules.google.com/task/16870416462764235046) started by @jreed91*