### PR TITLE
🛡️ Sentinel: [HIGH] Fix iframe src XSS in getYouTubeEmbedUrl

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2026-04-11 - [Fix iframe src XSS vector]
+**Vulnerability:** XSS vulnerability where `getYouTubeEmbedUrl` would return the raw string passed via MDX frontmatter directly into an `<iframe src="...">` without validation. If the string was an unsafe URI scheme like `javascript:`, the browser could execute the payload when the iframe renders or interacts.
+**Learning:** `iframe` `src` attributes are sensitive execution contexts. Relying on Regex to match valid URLs is insufficient if you allow the raw input to pass through as a fallback, as malicious payloads can completely bypass the Regex and be directly injected.
+**Prevention:** Use the native `URL` constructor (e.g. `new URL(url, 'http://localhost')`) to validate the protocol of user-provided strings used in `iframe` or `a` tags, specifically enforcing `http:` or `https:`. Additionally, handle safe root-relative fallbacks explicitly, defaulting to `about:blank` on failure.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,14 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('filters out unsafe URIs and returns about:blank', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('vbscript:msgbox(1)')).toBe('about:blank');
+  });
+
+  it('allows valid root-relative fallback paths', () => {
+    expect(getYouTubeEmbedUrl('/local-video.mp4')).toBe('/local-video.mp4');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,15 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Validate fallback URL to prevent XSS (e.g. javascript:)
+  try {
+    const url = new URL(videoUrl, 'http://localhost');
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URLs
+  }
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unvalidated raw fallback URL passed to `iframe` `src` attribute from MDX frontmatter.
🎯 **Impact:** Permitted unsafe URI schemes such as `javascript:`, exposing an XSS vector when user data fails the YouTube URL regex and is directly rendered.
🔧 **Fix:** Utilized native `URL` constructor to enforce secure `http:` or `https:` schemas, filtering unsafe strings to `about:blank`.
✅ **Verification:** Verified with the updated unit tests and test runner (`npm run test`), asserting that XSS vectors like `javascript:alert(1)` successfully fall back to `about:blank`.

---
*PR created automatically by Jules for task [14590986363459490496](https://jules.google.com/task/14590986363459490496) started by @jreed91*