### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS/SSRF in TalkLayout iframe source

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix SSRF/XSS in iframe source]
+**Vulnerability:** XSS/SSRF vulnerability where malicious strings provided to `videoUrl` in MDX frontmatter could bypass standard YouTube parsing and be directly injected into an `<iframe src="...">` attribute without checking for unsafe protocols like `javascript:` or `data:`.
+**Learning:** `iframe` `src` attributes can execute Javascript when using the `javascript:` protocol. If `src` relies on dynamic or user-controlled fallback URLs, parsing with `new URL()` with a base URL is an effective way to extract `.protocol` and reliably allowlist safe protocols (e.g., `http:`, `https:`, `about:`).
+**Prevention:** Whenever rendering an `iframe` with a dynamically resolved or user-controlled URL, always rigorously allowlist the allowed protocols. Use `new URL(url, 'http://localhost')` to properly extract `.protocol` since Regex or `.startsWith` validations can be bypassed with whitespace padding or unusual casing.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** XSS/SSRF vulnerability where malicious strings provided to `videoUrl` in MDX frontmatter could bypass standard YouTube parsing and be directly injected into an `<iframe src="...">` attribute without checking for unsafe protocols like `javascript:` or `data:`.
 **Learning:** `iframe` `src` attributes can execute Javascript when using the `javascript:` protocol. If `src` relies on dynamic or user-controlled fallback URLs, parsing with `new URL()` with a base URL is an effective way to extract `.protocol` and reliably allowlist safe protocols (e.g., `http:`, `https:`, `about:`).
 **Prevention:** Whenever rendering an `iframe` with a dynamically resolved or user-controlled URL, always rigorously allowlist the allowed protocols. Use `new URL(url, 'http://localhost')` to properly extract `.protocol` since Regex or `.startsWith` validations can be bypassed with whitespace padding or unusual casing.
+
+## 2025-03-03 - [Fix Stored XSS in Link href]
+**Vulnerability:** CodeQL flagged a stored cross-site scripting vulnerability in `app/components/TalkCard.tsx` on line 7 where `talk.slug` was directly interpolated into a `href` string without URL encoding.
+**Learning:** Even internal URLs generated from file slugs or database entries can be flagged as stored XSS by SAST tools if they are directly injected into `href` or `src` attributes without proper sanitization/encoding. Attackers could theoretically craft a slug like `"javascript:..."` or use special characters.
+**Prevention:** Always use `encodeURIComponent()` when interpolating dynamic data (like slugs or user input) into URL paths or query parameters.

--- a/app/components/TalkCard.tsx
+++ b/app/components/TalkCard.tsx
@@ -4,7 +4,7 @@ import { parseISO, format } from 'date-fns';
 
 export default function TalkCard({ talk }: { talk: Talk }) {
   return (
-    <Link href={`/talks/${talk.slug}`} className="w-full">
+    <Link href={`/talks/${encodeURIComponent(talk.slug)}`} className="w-full">
       <div className="w-full mb-8 transform hover:scale-[1.01] transition-all">
         <div className="flex flex-col justify-between md:flex-row">
           <h4 className="w-full mb-2 text-lg font-medium text-gray-900 md:text-xl dark:text-gray-100">

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -1,48 +1,63 @@
-import { describe, it, expect } from 'vitest';
-import { getYouTubeEmbedUrl } from './talks';
+import { describe, it, expect } from "vitest";
+import { getYouTubeEmbedUrl } from "./talks";
 
-describe('getYouTubeEmbedUrl', () => {
-  it('converts a standard youtube.com watch URL', () => {
-    const url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+describe("getYouTubeEmbedUrl", () => {
+  it("converts a standard youtube.com watch URL", () => {
+    const url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/dQw4w9WgXcQ'
+      "https://www.youtube.com/embed/dQw4w9WgXcQ",
     );
   });
 
-  it('converts a youtu.be short URL', () => {
-    const url = 'https://youtu.be/dQw4w9WgXcQ';
+  it("converts a youtu.be short URL", () => {
+    const url = "https://youtu.be/dQw4w9WgXcQ";
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/dQw4w9WgXcQ'
+      "https://www.youtube.com/embed/dQw4w9WgXcQ",
     );
   });
 
-  it('converts a youtube.com/embed URL', () => {
-    const url = 'https://www.youtube.com/embed/dQw4w9WgXcQ';
+  it("converts a youtube.com/embed URL", () => {
+    const url = "https://www.youtube.com/embed/dQw4w9WgXcQ";
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/dQw4w9WgXcQ'
+      "https://www.youtube.com/embed/dQw4w9WgXcQ",
     );
   });
 
-  it('converts a youtube.com/v/ URL', () => {
-    const url = 'https://www.youtube.com/v/dQw4w9WgXcQ';
+  it("converts a youtube.com/v/ URL", () => {
+    const url = "https://www.youtube.com/v/dQw4w9WgXcQ";
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/dQw4w9WgXcQ'
+      "https://www.youtube.com/embed/dQw4w9WgXcQ",
     );
   });
 
-  it('returns the original URL unchanged for non-YouTube URLs', () => {
-    const url = 'https://vimeo.com/123456789';
+  it("returns the original URL unchanged for non-YouTube URLs", () => {
+    const url = "https://vimeo.com/123456789";
     expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 
-  it('returns the original URL unchanged for empty string', () => {
-    expect(getYouTubeEmbedUrl('')).toBe('');
+  it("returns the original URL unchanged for empty string", () => {
+    expect(getYouTubeEmbedUrl("")).toBe("");
   });
 
-  it('handles video IDs with hyphens and underscores', () => {
-    const url = 'https://youtu.be/abc-def_123';
+  it("handles video IDs with hyphens and underscores", () => {
+    const url = "https://youtu.be/abc-def_123";
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/abc-def_123'
+      "https://www.youtube.com/embed/abc-def_123",
     );
+  });
+
+  it("blocks dangerous protocols like javascript:", () => {
+    const url = "javascript:alert(1)";
+    expect(getYouTubeEmbedUrl(url)).toBe("about:blank");
+  });
+
+  it("blocks dangerous protocols like data:", () => {
+    const url = "data:text/html,<script>alert(1)</script>";
+    expect(getYouTubeEmbedUrl(url)).toBe("about:blank");
+  });
+
+  it("safely allows root-relative paths", () => {
+    const url = "/local-video.mp4";
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from "fs";
+import path from "path";
 
 type TalkMetadata = {
   title: string;
@@ -20,14 +20,14 @@ function parseFrontmatter(fileContent: string) {
   let frontmatterRegex = /---\s*([\s\S]*?)\s*---/;
   let match = frontmatterRegex.exec(fileContent);
   let frontMatterBlock = match![1];
-  let content = fileContent.replace(frontmatterRegex, '').trim();
-  let frontMatterLines = frontMatterBlock.trim().split('\n');
+  let content = fileContent.replace(frontmatterRegex, "").trim();
+  let frontMatterLines = frontMatterBlock.trim().split("\n");
   let metadata: Partial<TalkMetadata> = {};
 
   frontMatterLines.forEach((line) => {
-    let [key, ...valueArr] = line.split(': ');
-    let value = valueArr.join(': ').trim();
-    value = value.replace(/^['"](.*)['"]$/, '$1'); // Remove quotes
+    let [key, ...valueArr] = line.split(": ");
+    let value = valueArr.join(": ").trim();
+    value = value.replace(/^['"](.*)['"]$/, "$1"); // Remove quotes
     metadata[key.trim() as keyof TalkMetadata] = value;
   });
 
@@ -35,11 +35,11 @@ function parseFrontmatter(fileContent: string) {
 }
 
 function getMDXFiles(dir: fs.PathLike) {
-  return fs.readdirSync(dir).filter((file) => path.extname(file) === '.mdx');
+  return fs.readdirSync(dir).filter((file) => path.extname(file) === ".mdx");
 }
 
 function readMDXFile(filePath: fs.PathOrFileDescriptor) {
-  let rawContent = fs.readFileSync(filePath, 'utf-8');
+  let rawContent = fs.readFileSync(filePath, "utf-8");
   return parseFrontmatter(rawContent);
 }
 
@@ -58,15 +58,26 @@ function getMDXData(dir: string): Talk[] {
 }
 
 export function getTalks(): Talk[] {
-  return getMDXData(path.join(process.cwd(), 'content', 'talks'));
+  return getMDXData(path.join(process.cwd(), "content", "talks"));
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return "";
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const url = new URL(videoUrl, "http://localhost");
+    if (url.protocol === "http:" || url.protocol === "https:") {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URLs
+  }
+  return "about:blank";
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: XSS/SSRF vulnerability where malicious fallback URLs could bypass YouTube regex parsing and directly execute scripts inside the dynamic `<iframe src={embedUrl}>` due to lack of protocol validation.
🎯 Impact: Attackers could execute arbitrary Javascript in users' browsers by feeding a `javascript:alert(1)` URL via frontmatter metadata.
🔧 Fix: Validated URLs using the Node/Browser `URL` constructor (which accurately extracts `protocol` even when obfuscated), ensuring the fallback URL strictly belongs to an allowed protocol list (`http:`, `https:`, or safe root-relative path).
✅ Verification: Tested via Vitest to ensure dangerous payloads (`javascript:`, `data:`) resolve to `about:blank`. Verified standard behavior for regular URLs.

---
*PR created automatically by Jules for task [2144277570264757349](https://jules.google.com/task/2144277570264757349) started by @jreed91*