### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability via iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix XSS via iframe src]
+**Vulnerability:** XSS vulnerability in `TalkLayout.tsx` where an untrusted fallback `videoUrl` could be passed to an `iframe`'s `src` attribute without protocol validation.
+**Learning:** `iframe` `src` attributes are vulnerable to `javascript:` and `data:` URIs. Simple regex or `startsWith` checks can be bypassed (e.g. by padding with whitespace). The native `URL` constructor is a reliable way to extract and validate the `.protocol` property.
+**Prevention:** Always parse untrusted URIs using the `URL` constructor and enforce an allowlist of safe protocols (`http:`, `https:`). Explicitly handle root-relative paths or fallback safely to `about:blank`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -35,8 +35,8 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 
-  it('returns the original URL unchanged for empty string', () => {
-    expect(getYouTubeEmbedUrl('')).toBe('');
+  it('returns about:blank for empty string', () => {
+    expect(getYouTubeEmbedUrl('')).toBe('about:blank');
   });
 
   it('handles video IDs with hyphens and underscores', () => {
@@ -44,5 +44,23 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl(url)).toBe(
       'https://www.youtube.com/embed/abc-def_123'
     );
+  });
+
+  it('allows safe http/https fallback URLs', () => {
+    expect(getYouTubeEmbedUrl('https://example.com/video.mp4')).toBe('https://example.com/video.mp4');
+    expect(getYouTubeEmbedUrl('http://example.com/video.mp4')).toBe('http://example.com/video.mp4');
+  });
+
+  it('allows root-relative fallback URLs', () => {
+    expect(getYouTubeEmbedUrl('/local-video.mp4')).toBe('/local-video.mp4');
+  });
+
+  it('rejects dangerous protocols (javascript:)', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('  javascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('rejects dangerous protocols (data:)', () => {
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
   });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,18 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Sentinel: Sanitize fallback URLs to prevent XSS via iframe src
+  if (!videoUrl) return 'about:blank';
+
+  try {
+    const parsedUrl = new URL(videoUrl, 'http://localhost');
+    if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // URL parsing failed
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** An XSS vulnerability was identified in `TalkLayout.tsx` where an untrusted fallback `videoUrl` could be passed directly to an `iframe`'s `src` attribute without protocol validation. This could allow execution of arbitrary JavaScript via `javascript:` or `data:` URIs if malicious data was present in the MDX frontmatter.
🎯 **Impact:** If exploited, an attacker could execute arbitrary JavaScript within the context of the user's browser, potentially leading to session hijacking or unauthorized actions.
🔧 **Fix:** Updated `getYouTubeEmbedUrl` in `app/db/talks.ts` to explicitly parse untrusted fallback URLs using the native `URL` constructor. It now enforces an allowlist of safe protocols (`http:`, `https:`) and cleanly handles root-relative paths by validating against a dummy base URL (`http://localhost`), securely falling back to `about:blank` for dangerous protocols or parsing errors. Unit tests have been added to verify that dangerous protocols are rejected.
✅ **Verification:** Run `npm run test` to verify that `app/db/talks.test.ts` successfully prevents dangerous fallback URIs and accepts valid ones.

Additionally, added an entry to `.jules/sentinel.md` documenting this finding.

---
*PR created automatically by Jules for task [10667852026148069329](https://jules.google.com/task/10667852026148069329) started by @jreed91*