### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in getYouTubeEmbedUrl

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2024-05-18 - [Fix XSS Vulnerability in YouTube Embed Fallback URL]
+**Vulnerability:** XSS vulnerability where non-YouTube fallback URLs in `getYouTubeEmbedUrl` inside `app/db/talks.ts` were passed unchecked to an iframe's `src` attribute. This allowed execution of malicious `javascript:` and `data:` URIs if passed as a `videoUrl` in MDX metadata.
+**Learning:** Returning unfiltered URLs to act as fallback iframe `src`s can trigger JavaScript execution if it evaluates to a `javascript:` or `data:` schema. Always validate schemas for `href` and `src` links originating from data or MDX files.
+**Prevention:** Check the URL's protocol property strictly with `new URL(url, 'http://localhost')` before returning it as a safe fallback link. Default any unmatched schema or unparseable URLs to `about:blank`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -30,13 +30,13 @@ describe('getYouTubeEmbedUrl', () => {
     );
   });
 
-  it('returns the original URL unchanged for non-YouTube URLs', () => {
+  it('returns the original URL unchanged for non-YouTube HTTP/HTTPS URLs', () => {
     const url = 'https://vimeo.com/123456789';
     expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 
-  it('returns the original URL unchanged for empty string', () => {
-    expect(getYouTubeEmbedUrl('')).toBe('');
+  it('returns about:blank for empty string', () => {
+    expect(getYouTubeEmbedUrl('')).toBe('about:blank');
   });
 
   it('handles video IDs with hyphens and underscores', () => {
@@ -44,5 +44,23 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl(url)).toBe(
       'https://www.youtube.com/embed/abc-def_123'
     );
+  });
+
+  it('blocks javascript: URIs to prevent XSS', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+
+    const urlWithSpaces = '  javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(urlWithSpaces)).toBe('about:blank');
+  });
+
+  it('blocks data: URIs to prevent XSS', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('allows root-relative paths', () => {
+    const url = '/local-video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,25 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return 'about:blank';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Security Enhancement: Validate non-YouTube URLs to prevent XSS via javascript: or data: URIs
+  // in iframe src attributes. Allow http, https, or root-relative paths.
+  try {
+    const url = new URL(videoUrl, 'http://localhost');
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URL formatting errors
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `getYouTubeEmbedUrl` function in `app/db/talks.ts` incorrectly returned unmatched URLs unmodified to be used as a fallback. If a malicious `javascript:` or `data:` schema was inserted inside the `videoUrl` field of an MDX file, it could cause an XSS vulnerability when passed to the `src` attribute of an `iframe`.
🎯 Impact: Attackers or malicious MDX files could execute arbitrary JavaScript inside the application context.
🔧 Fix: Validated the protocol of the fallback URL using the native `URL` API and the `http://localhost` base to prevent execution of unapproved schemas. Any unknown schemas (e.g. `javascript:`) now safely default to `about:blank`. Tests were added in `app/db/talks.test.ts`.
✅ Verification: `npm run test` passes with newly added XSS test cases.

---
*PR created automatically by Jules for task [12590472498295008500](https://jules.google.com/task/12590472498295008500) started by @jreed91*