### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in getYouTubeEmbedUrl

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+## 2024-05-18 - [Fix Server-Side Request Forgery / XSS in getYouTubeEmbedUrl]
+**Vulnerability:** XSS and SSRF vulnerability where fallback logic in `getYouTubeEmbedUrl` directly returned any unverified string (including `javascript:` or `data:`) into an iframe `src` if it didn't match the YouTube regex.
+**Learning:** Returning unvalidated fallback URLs for iframe sources can lead to XSS if a content author accidentally or maliciously includes unsafe protocols (e.g. `javascript:alert(1)`).
+**Prevention:** Use the native `URL` constructor (e.g. `new URL(url, 'http://localhost')`) to reliably extract and check the `.protocol` property and enforce safe protocols like `http:` and `https:`, returning `about:blank` for unsafe inputs.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -35,6 +35,21 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 
+  it('sanitizes unsafe protocols like javascript:', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl(' javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('\tjavascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('sanitizes unsafe protocols like data:', () => {
+    expect(getYouTubeEmbedUrl('data:text/html,<html>')).toBe('about:blank');
+  });
+
+  it('allows protocol-relative URLs or local paths', () => {
+    expect(getYouTubeEmbedUrl('//vimeo.com/123')).toBe('//vimeo.com/123');
+    expect(getYouTubeEmbedUrl('/local/video.mp4')).toBe('/local/video.mp4');
+  });
+
   it('returns the original URL unchanged for empty string', () => {
     expect(getYouTubeEmbedUrl('')).toBe('');
   });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,24 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Security: Prevent XSS from unsafe protocols like javascript: or data:
+  // if a malicious URL bypasses the regex check.
+  try {
+    const url = new URL(videoUrl, 'http://localhost');
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      return videoUrl;
+    }
+    return 'about:blank';
+  } catch {
+    return 'about:blank';
+  }
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The fallback behavior in `getYouTubeEmbedUrl` returned unmodified URLs, opening a potential XSS vector if authors supply unsafe protocols like `javascript:` or `data:`.
🎯 Impact: Attackers could execute arbitrary JavaScript via malicious iframe `src` contents.
🔧 Fix: Used the native URL constructor to parse the URI and enforced protocol safety (only `http:` and `https:`), while allowing local absolute and protocol-relative URLs. Unsafe inputs are sanitized to `about:blank`.
✅ Verification: Ran `npm run test` successfully with new explicit assertions for `javascript:`, `data:`, empty strings, valid YouTube URLs, and local relative paths.

---
*PR created automatically by Jules for task [13617796551323820646](https://jules.google.com/task/13617796551323820646) started by @jreed91*