### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe src parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-04-18 - [Fix Stored XSS via Malicious URIs in IFrames]
+**Vulnerability:** XSS vulnerability in `getYouTubeEmbedUrl` inside `app/db/talks.ts` where the fallback URL to be rendered in an `iframe`'s `src` attribute did not have its protocol validated, allowing `javascript:` or `data:` URIs.
+**Learning:** `javascript:` and `data:` URIs inside `iframe` `src` attributes can execute arbitrary JavaScript in the context of the vulnerable page. When using URLs from untrusted or user-controlled sources (like Markdown frontmatter), validating that the protocol is exactly `http:` or `https:` is required to prevent XSS.
+**Prevention:** Use the `new URL(url, base)` constructor to parse external URLs safely and check their `.protocol` property, dropping anything that is not `http:` or `https:`. Do not rely solely on Regex to validate URLs, as malicious payloads can hide behind whitespace or formatting tricks.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,20 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('blocks javascript: URIs to prevent XSS', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('blocks padded javascript: URIs to prevent XSS', () => {
+    expect(getYouTubeEmbedUrl('   javascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('blocks data: URIs to prevent XSS', () => {
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
+  });
+
+  it('allows relative paths (falling back to http: via localhost base URL)', () => {
+    expect(getYouTubeEmbedUrl('/foo/bar')).toBe('/foo/bar');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,25 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) {
+    return '';
+  }
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
+
+  try {
+    const parsedUrl = new URL(videoUrl, 'http://localhost');
+    if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+      return 'about:blank';
+    }
+  } catch (e) {
+    return 'about:blank';
+  }
+
   return videoUrl;
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** `getYouTubeEmbedUrl` in `app/db/talks.ts` does not validate the protocol of fallback URLs, allowing injection of `javascript:` or `data:` URIs if provided via MDX frontmatter.
🎯 **Impact:** When rendered in `TalkLayout.tsx` via the `iframe` `src` attribute, an attacker who controls the markdown can execute arbitrary JavaScript in the context of the user's session (Stored XSS).
🔧 **Fix:** Changed the fallback logic to use `new URL(url, base)` to safely validate the `.protocol` property, returning `about:blank` for anything other than `http:` or `https:`.
✅ **Verification:** Unit tests added in `app/db/talks.test.ts` to confirm `javascript:`, padded `javascript:`, and `data:` URIs are safely blocked, while valid URLs and relative paths are preserved.

---
*PR created automatically by Jules for task [14104269620150402000](https://jules.google.com/task/14104269620150402000) started by @jreed91*