### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2024-10-24 - [XSS via Unsafe iframe src]
+**Vulnerability:** The `TalkLayout` component renders an `iframe` with a `src` derived from `talk.metadata.videoUrl`. The `getYouTubeEmbedUrl` function did not validate the URL protocol, allowing execution of XSS payloads if an unsafe URL like `javascript:alert(1)` was provided in the MDX frontmatter.
+**Learning:** Returning a raw string directly to an `iframe src` attribute allows `javascript:` execution. If a URL doesn't match an expected trusted format (like YouTube domains), its protocol must be verified before rendering.
+**Prevention:** Use the native `URL` constructor to validate that the `.protocol` is safe (`http:`, `https:`). If unsafe, fallback to `about:blank`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,19 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('sanitizes javascript: URLs to about:blank to prevent XSS', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('  javascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('sanitizes data: URLs to about:blank to prevent XSS', () => {
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe(
+      'about:blank'
+    );
+  });
+
+  it('allows relative URLs', () => {
+    expect(getYouTubeEmbedUrl('/static/video.mp4')).toBe('/static/video.mp4');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,22 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const parsedUrl = new URL(videoUrl, 'http://localhost');
+    if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URLs
+  }
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: The `TalkLayout` component renders an `iframe` with a `src` attribute derived directly from `talk.metadata.videoUrl` using `getYouTubeEmbedUrl`. The function did not validate the URL protocol, meaning an attacker could provide an MDX frontmatter video URL like `javascript:alert(1)` and it would be passed directly to the iframe, leading to XSS execution.
🎯 **Impact**: Execution of malicious JavaScript in the context of the domain.
🔧 **Fix**: Updated `getYouTubeEmbedUrl` to parse the provided URL using the native `URL` constructor (with a dummy base to handle relative URLs). It now enforces `http:` or `https:` protocols and falls back to `about:blank` for unsafe protocols.
✅ **Verification**: Tests in `app/db/talks.test.ts` have been updated and all tests pass via `npm run test`.

---
*PR created automatically by Jules for task [3845664392680641588](https://jules.google.com/task/3845664392680641588) started by @jreed91*