### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF/XSS in Iframe SRC via Fallback

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix SSRF/XSS in Iframe SRC via Fallback]
+**Vulnerability:** XSS and SSRF vulnerability in `app/db/talks.ts` where an unvalidated `videoUrl` was used as a direct fallback for the `<iframe>` `src` attribute if it did not match a YouTube pattern.
+**Learning:** Using untrusted data directly in an `<iframe>` `src` allows execution of `javascript:` or `data:` URIs, leading to XSS. Regular expression checks may fail to match, unexpectedly falling back to the original payload.
+**Prevention:** Always parse and validate protocols using `new URL(url, 'http://localhost')` when accepting arbitrary input for `src` attributes. Only allow explicit safe protocols like `http:` and `https:`, or fallback to `about:blank`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -35,6 +35,12 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 
+  it('returns about:blank for unsafe protocols', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('vbscript:msgbox("hello")')).toBe('about:blank');
+  });
+
   it('returns the original URL unchanged for empty string', () => {
     expect(getYouTubeEmbedUrl('')).toBe('');
   });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,16 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
+
+  // Prevent XSS/SSRF by validating the fallback URL protocol
+  try {
+    const url = new URL(videoUrl, 'http://localhost');
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return 'about:blank';
+    }
+  } catch (e) {
+    return 'about:blank';
+  }
+
   return videoUrl;
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: XSS and SSRF vulnerability in `app/db/talks.ts` where an unvalidated `videoUrl` was used as a direct fallback for the `<iframe>` `src` attribute if it did not match a YouTube pattern.
🎯 Impact: Using untrusted data directly in an `<iframe>` `src` allows execution of `javascript:` or `data:` URIs, leading to XSS.
🔧 Fix: Parse and validate protocols using `new URL(url, 'http://localhost')` when accepting arbitrary input for `src` attributes. Only allow explicit safe protocols like `http:` and `https:`, or fallback to `about:blank`. Added tests to cover these unsafe URI scenarios.
✅ Verification: Ran `npm run test` and `npm run lint` successfully.

---
*PR created automatically by Jules for task [3855405139645426209](https://jules.google.com/task/3855405139645426209) started by @jreed91*