### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2024-05-15 - [Preventing iframe SSRF and XSS]
+**Vulnerability:** External URLs passed into `iframe` `src` attributes without validation allow XSS (via `javascript:` or `data:`) or internal scanning.
+**Learning:** Checking for YouTube URLs is not enough if a fallback just uses the raw URL. Native `URL` object allows safe protocol parsing and empty string handling (which relative routes map to `http:` protocol) to validate safe links effectively.
+**Prevention:** Always validate protocols (restrict to `http:` or `https:`) using the `URL` constructor (e.g. `new URL(url, 'http://localhost')`) when placing user-controlled strings into `src` attributes, falling back to safe defaults like `'about:blank'`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,23 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('blocks javascript: URLs', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('  javascript:alert(1)  ')).toBe('about:blank');
+  });
+
+  it('blocks data: URLs', () => {
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
+  });
+
+  it('allows http and https URLs', () => {
+    expect(getYouTubeEmbedUrl('http://example.com/video')).toBe('http://example.com/video');
+    expect(getYouTubeEmbedUrl('https://example.com/video')).toBe('https://example.com/video');
+  });
+
+  it('allows relative paths', () => {
+    expect(getYouTubeEmbedUrl('/local/video.mp4')).toBe('/local/video.mp4');
+    expect(getYouTubeEmbedUrl('local/video.mp4')).toBe('local/video.mp4');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,24 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const parsedUrl = new URL(videoUrl, 'http://localhost');
+    if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Parsing failed, return safe fallback
+  }
+
+  // Prevent XSS via unsafe protocols (e.g. javascript:) in iframe src
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: External URLs passed directly to `getYouTubeEmbedUrl` could fallback to returning the unsafe, original URL if it doesn't match a YouTube format. This URL is then placed directly into an `iframe` `src` attribute. If a malicious URI like `javascript:alert(1)` or `data:text/html,...` is provided, it causes XSS execution within the iframe context.
🎯 Impact: Attackers could execute arbitrary JavaScript within the context of the user's browser, leading to session hijacking, defacement, or redirection to malicious sites.
🔧 Fix: Updated `getYouTubeEmbedUrl` to safely parse the fallback URL using the native `URL` constructor (providing a localhost base to allow relative paths to safely resolve to `http:`). Only allows `http:` and `https:` protocols, falling back to a safe `about:blank` for dangerous protocols.
✅ Verification: Covered by the newly added vitest tests which assert `javascript:` and `data:` URIs are transformed to `about:blank`, while `http:`, `https:`, and relative paths pass safely.

---
*PR created automatically by Jules for task [2379212476011310619](https://jules.google.com/task/2379212476011310619) started by @jreed91*