### PR TITLE
🛡️ Sentinel: [HIGH] Sanitize iframe URLs to prevent XSS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-02-28 - [Sanitize iframe URLs to prevent XSS]
+**Vulnerability:** The `getYouTubeEmbedUrl` in `app/db/talks.ts` was returning any non-matching string exactly as provided, which was then injected into an `iframe src` attribute in `app/components/TalkLayout.tsx`. This created an XSS/SSRF risk if malicious URLs (like `javascript:alert(1)` or `data:...`) were somehow provided via the input.
+**Learning:** Even when extracting components of valid URLs using Regex, ensure the default/fallback logic returns safe outputs, or enforces an allowed protocol list (e.g. `http:` / `https:`).
+**Prevention:** Use the native `URL` constructor with a safe base URL (e.g. `new URL(url, 'http://localhost')`) to parse and validate protocols for unknown strings. If the protocol is safe, allow it; else default to `about:blank`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -30,9 +30,15 @@ describe('getYouTubeEmbedUrl', () => {
     );
   });
 
-  it('returns the original URL unchanged for non-YouTube URLs', () => {
+  it('returns the original URL unchanged for non-YouTube HTTP/HTTPS URLs', () => {
     const url = 'https://vimeo.com/123456789';
     expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
+
+  it('sanitizes unsafe URLs like javascript: to about:blank', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('  javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
   });
 
   it('returns the original URL unchanged for empty string', () => {

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,23 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const parsedUrl = new URL(videoUrl, 'http://localhost');
+    if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore parsing errors and fall through to fallback
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `getYouTubeEmbedUrl` function in `app/db/talks.ts` was returning any non-matching string exactly as provided, which was then injected into an `iframe src` attribute in `app/components/TalkLayout.tsx`. This created an XSS/SSRF risk if malicious URLs (like `javascript:alert(1)` or `data:...`) were somehow provided via the input.
🎯 **Impact:** Potential Cross-Site Scripting (XSS) allowing arbitrary JavaScript execution via `javascript:` URIs, or Server-Side Request Forgery depending on how the URL was loaded.
🔧 **Fix:** Updated the `getYouTubeEmbedUrl` function to validate fallback URLs. It parses the URL using the native `URL` constructor. If the protocol is safe (`http:` or `https:`), it allows the URL (which correctly includes valid relative paths via a safe base URL). Otherwise, it safely defaults to `about:blank`.
✅ **Verification:** Added dedicated unit tests in `app/db/talks.test.ts` to assert that unsafe `javascript:` and `data:` URIs are properly sanitized to `about:blank`, while standard `http:`/`https:` URLs and relative paths pass safely. Ran `npm test` successfully.

---
*PR created automatically by Jules for task [8692194918240670744](https://jules.google.com/task/8692194918240670744) started by @jreed91*