### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF/XSS in iframe source URLs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+## 2024-05-24 - SSRF/XSS in iframe source URLs
+**Vulnerability:** External URLs specified in Markdown frontmatter (`videoUrl`) were passed into `getYouTubeEmbedUrl` which simply returned the original URL if it wasn't a YouTube format. This URL was then used directly in an `iframe`'s `src` attribute. This allowed for potential XSS via `javascript:` or `data:` URIs or SSRF.
+**Learning:** URL handlers for user-provided external links or iframe sources must validate the protocol to ensure only safe origins (like `http:` and `https:`) are allowed. The native `new URL(url, base)` constructor is an effective way to parse protocols without Regex bypasses.
+**Prevention:** Validate protocols (`url.protocol === 'http:' || url.protocol === 'https:'`) for any dynamically generated or user-provided `iframe` `src` attributes, safely falling back to `about:blank`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,10 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for unsafe protocols to prevent XSS', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('vbscript:msgbox("hello")')).toBe('about:blank');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,20 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  if (!videoUrl) {
+    return videoUrl;
+  }
+
+  // Security Fix: Prevent XSS/SSRF from unsafe protocols (javascript:, data:)
+  try {
+    const url = new URL(videoUrl, 'http://localhost');
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // URL parsing failed
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unsafe URLs from Markdown frontmatter (`videoUrl`) were passed into `getYouTubeEmbedUrl` and returned raw if they weren't YouTube links. This resulted in the raw URL being rendered directly in an `iframe` `src` attribute.
🎯 **Impact:** Potential Cross-Site Scripting (XSS) via `javascript:` or `data:` URIs or Server-Side Request Forgery (SSRF) if malicious or invalid inputs were added to markdown files.
🔧 **Fix:** Updated `getYouTubeEmbedUrl` to enforce safe protocols (`http:` or `https:`) using the `URL` constructor. Unsafe protocols now fall back to `about:blank`.
✅ **Verification:** Added test cases ensuring `javascript:`, `data:`, and `vbscript:` URLs return `about:blank`. Ran the Vitest suite cleanly.

---
*PR created automatically by Jules for task [12087476687980226196](https://jules.google.com/task/12087476687980226196) started by @jreed91*