### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS/SSRF in iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Iframe SSRF/XSS]
+**Vulnerability:** XSS/SSRF vulnerability where a markdown frontmatter field `videoUrl` directly fed the `src` attribute of an `iframe` in `app/components/TalkLayout.tsx` without protocol validation for non-YouTube links.
+**Learning:** `iframe src` properties can accept unsafe `javascript:` or `data:` URIs. Using simple string methods (like regex or `startsWith`) to check for safe protocols is insufficient because whitespace padding can bypass these checks.
+**Prevention:** For any URL user input used in an `iframe src`, parse it with the native `URL` constructor (providing a fallback base to catch relative paths) and strictly allow-list safe protocols like `http:` or `https:`, falling back to safe paths (e.g., `about:blank`).

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,19 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for dangerous protocols', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for data URIs', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('allows root-relative paths', () => {
+    const url = '/local-video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe('/local-video.mp4');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,22 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return videoUrl;
+    }
+    return 'about:blank';
+  } catch (e) {
+    return 'about:blank';
+  }
 }


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix XSS/SSRF in iframe src

🚨 Severity: HIGH
💡 Vulnerability: The markdown frontmatter field `videoUrl` directly fed the `src` attribute of an `iframe` in `app/components/TalkLayout.tsx` without protocol validation for non-YouTube links. This allowed arbitrary protocols like `javascript:` or `data:`.
🎯 Impact: Attackers could potentially execute arbitrary scripts within the context of the page or make unauthorized requests (SSRF) if they can control the frontmatter.
🔧 Fix: Updated `getYouTubeEmbedUrl` in `app/db/talks.ts` to utilize the native `URL` constructor (with a fallback base) to strictly allow-list `http:` and `https:` protocols, safely falling back to `about:blank`.
✅ Verification: Ran `npm run test` against the updated vitest assertions for empty, relative, data, and javascript URIs.

---
*PR created automatically by Jules for task [523690537060649044](https://jules.google.com/task/523690537060649044) started by @jreed91*