### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF/XSS in MDX Iframe Frontmatter

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2024-04-26 - [XSS/SSRF via MDX Iframe Frontmatter]
+**Vulnerability:** The `getYouTubeEmbedUrl` function did not validate the protocol of non-YouTube URLs. Because its output is directly used as the `src` attribute of an `iframe` in `app/components/TalkLayout.tsx`, a malicious author could inject `javascript:` or `data:` URLs via MDX frontmatter, leading to XSS or SSRF execution when the user views the talk page.
+**Learning:** URLs parsed from untrusted sources (like MDX frontmatter) that bypass external domains must have their protocols validated before being used in sensitive DOM attributes like `iframe src` or `a href`.
+**Prevention:** Validate protocols using the native `URL` constructor to ensure they match `http:` or `https:`. Return `about:blank` for invalid protocols to ensure safe failure.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,19 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for javascript: URLs', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for data: URLs', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('allows relative URLs by resolving to the base http protocol', () => {
+    const url = '/my-video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,23 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const parsedUrl = new URL(videoUrl, 'http://localhost');
+    if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URLs
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unvalidated URL protocols passing through `getYouTubeEmbedUrl` directly into `iframe src` attributes in `app/components/TalkLayout.tsx`.
🎯 **Impact:** XSS or SSRF execution via malicious MDX frontmatter (e.g. `videoUrl: "javascript:alert(1)"`).
🔧 **Fix:** Parse and validate external URLs to enforce `http:` or `https:`. Return `about:blank` on malicious inputs to fail safely. Added comprehensive test coverage.
✅ **Verification:** Unit tests confirm that valid YouTube URLs map successfully to `/embed/` paths, standard HTTP(S) links remain valid, and unsafe inputs fail safely to `about:blank`. Tested successfully via `npm run test`.

---
*PR created automatically by Jules for task [6362095770690676319](https://jules.google.com/task/6362095770690676319) started by @jreed91*