### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS in Video Iframes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe XSS in Talks]
+**Vulnerability:** XSS vulnerability where user-provided `videoUrl` in talk MDX files was directly embedded into `<iframe> src` attributes without protocol validation.
+**Learning:** External links sourced from MDX frontmatter (e.g., `videoUrl` fallback in `getYouTubeEmbedUrl`) must enforce `http://` or `https://` protocol validation to prevent `javascript:` or `data:` payloads from being executed in the context of the application when loaded in an iframe.
+**Prevention:** Always validate URL protocols using the native `URL` constructor (`new URL(url, 'http://localhost')`) before using them in dynamic `iframe` `src` attributes, explicitly rejecting unsafe schemas and falling back to `about:blank`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,13 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('sanitizes unsafe URLs like javascript: protocols', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
+  });
+
+  it('allows root-relative URLs', () => {
+    expect(getYouTubeEmbedUrl('/local/video.mp4')).toBe('/local/video.mp4');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,23 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const parsedUrl = new URL(videoUrl, 'http://localhost');
+    if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (error) {
+    // Ignore invalid URLs
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix XSS Vulnerability in Video Iframes

🚨 **Severity:** HIGH
💡 **Vulnerability:** XSS vulnerability where `getYouTubeEmbedUrl` would return unmodified user input for non-YouTube URLs. This allowed `javascript:alert(1)` payloads to be directly assigned to `<iframe> src` attributes in `app/components/TalkLayout.tsx`.
🎯 **Impact:** If an attacker can control or modify the `videoUrl` frontmatter of a talk MDX file, they could execute arbitrary JavaScript in the context of the user's browser via the iframe.
🔧 **Fix:** Introduced proper protocol validation using the native `URL` constructor. The function now ensures the protocol is either `http:` or `https:`. If the protocol is unsafe (`javascript:`, `data:`), it falls back to `about:blank`. Root-relative paths are also permitted.
✅ **Verification:** Added test cases in `app/db/talks.test.ts` to assert `javascript:` and `data:` URLs are correctly blocked, and verified by running the vitest test suite.

---
*PR created automatically by Jules for task [18080126422051298465](https://jules.google.com/task/18080126422051298465) started by @jreed91*