### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in Talk iframe source

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2024-05-26 - [Fix SSRF/XSS in iframe source]
+**Vulnerability:** A cross-site scripting (XSS) vulnerability existed where user-provided `videoUrl` input that did not match the expected YouTube format was passed directly to the `src` attribute of an `iframe` tag without validation in `TalkLayout`. Attackers could inject `javascript:` or `data:` URIs leading to arbitrary code execution within the iframe context.
+**Learning:** React safely encodes standard text contents but treats the `src` attribute of `iframe` tags as safe by default, expecting developers to provide trusted URLs. Bypassing custom RegEx matching creates an open door for arbitrary string fallbacks. Relying on the built-in `new URL()` API ensures robust validation of protocols.
+**Prevention:** Always parse and validate protocols for dynamically generated `iframe` `src` inputs or any `a` tag `href` links using the built-in `URL` constructor (enforcing `http:` or `https:`) before rendering, and return a safe fallback like `about:blank` on error.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,18 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for javascript: URLs', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('returns about:blank for data: URLs', () => {
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe(
+      'about:blank'
+    );
+  });
+
+  it('returns the URL for root-relative URLs', () => {
+    expect(getYouTubeEmbedUrl('/local-video.mp4')).toBe('/local-video.mp4');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,23 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const parsedUrl = new URL(videoUrl, 'http://localhost');
+    if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore URL parsing errors
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
* 🚨 **Severity:** HIGH
* 💡 **Vulnerability:** Unvalidated fallback in `getYouTubeEmbedUrl` allowed XSS via `javascript:` or `data:` URIs injected into the `src` attribute of an `iframe` in `TalkLayout`.
* 🎯 **Impact:** Could allow execution of arbitrary JavaScript within the iframe context if malicious URLs were provided in MDX frontmatter.
* 🔧 **Fix:** Introduced protocol validation using `new URL()` with a base URL to strictly allow `http:`, `https:`, or root-relative paths, falling back securely to `about:blank`.
* ✅ **Verification:** Run `npm run test` to verify malicious URLs are rejected and legitimate URLs operate correctly.

---
*PR created automatically by Jules for task [11153312692477191085](https://jules.google.com/task/11153312692477191085) started by @jreed91*