### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in video iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix URL Protocol XSS in iframes]
+**Vulnerability:** XSS via unsafe URL protocols (`javascript:`, `data:`) in dynamic `iframe` `src` attributes generated from user-provided MDX frontmatter (`videoUrl`).
+**Learning:** Checking for safe URL protocols must use the `URL` constructor (e.g. `new URL(url, 'http://localhost')`) because simple string matching or regex can be bypassed using whitespace padding (like `   javascript:alert(1)`).
+**Prevention:** Always validate protocols dynamically using the native `URL` parsing API before using unverified inputs in `iframe` or `a` tags, falling back to a safe default like `about:blank`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,18 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for javascript protocol URLs (XSS)', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('  javascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('returns about:blank for data protocol URLs (XSS)', () => {
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
+  });
+
+  it('allows local paths', () => {
+    const url = '/local/video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,17 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  if (!videoUrl) return '';
+
+  try {
+    const parsedUrl = new URL(videoUrl, 'http://localhost');
+    if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (error) {
+    // Ignore error and fall through to return about:blank
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
This PR addresses a Cross-Site Scripting (XSS) vulnerability found in the `getYouTubeEmbedUrl` utility function, which is used to populate `iframe` `src` attributes for talk videos.

**Vulnerability:**
The function was acting as a pass-through for any string that wasn't matched as a valid YouTube URL. This meant that `javascript:alert(1)` or `data:text/html,...` payloads could be directly injected into an `iframe` tag, resulting in XSS.

**Fix:**
Implemented strict protocol validation using the native `URL` API. It now checks that non-YouTube URLs use either the `http:` or `https:` protocol. If parsing fails or the protocol is malicious, it safely falls back to `about:blank`. Relative paths (like `/local/video.mp4`) are still permitted by passing a safe base URL (`http://localhost`) to the `URL` constructor.

**Testing:**
Added comprehensive unit tests to `app/db/talks.test.ts` to cover `javascript:` and `data:` schemes, ensuring they are blocked, while verifying that regular URLs and local paths continue to work. All 45 vitest tests pass successfully.

---
*PR created automatically by Jules for task [8955797722732644079](https://jules.google.com/task/8955797722732644079) started by @jreed91*