### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe src XSS]
+**Vulnerability:** XSS vulnerability where untrusted URLs provided in frontmatter (like `javascript:alert(1)`) were injected directly into the `src` attribute of an `iframe` via `getYouTubeEmbedUrl` in `app/db/talks.ts`.
+**Learning:** `iframe` `src` attributes can execute arbitrary JavaScript if the protocol is `javascript:`. Even seemingly innocent link handling can be an attack vector if data is user-controlled or malicious content enters the system via external sources like MDX files.
+**Prevention:** Always validate the protocol of dynamically generated or external URLs using the native `URL` constructor. If the URL doesn't use `http:` or `https:`, return a safe fallback like `about:blank`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,14 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('handles unsafe URLs by returning about:blank', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('handles another unsafe URL', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,17 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  if (!videoUrl) return '';
+
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URLs
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unvalidated user-supplied strings or MDX frontmatter values were injected directly into an `iframe`'s `src` attribute. Attackers could supply `javascript:` or `data:` payloads to execute arbitrary code within the context of the application.
🎯 **Impact:** Potential Cross-Site Scripting (XSS) via maliciously crafted Markdown files or untrusted data reaching the talk metadata parsing.
🔧 **Fix:** Refactored `getYouTubeEmbedUrl` to explicitly parse the fallback URL using the native `URL` constructor. If the protocol is not `http:` or `https:`, it returns `about:blank`.
✅ **Verification:** Verified by unit tests explicitly targeting `javascript:alert(1)` and `data:text/html,...` which now successfully fall back to `about:blank`.

---
*PR created automatically by Jules for task [2662420557680065986](https://jules.google.com/task/2662420557680065986) started by @jreed91*