### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe XSS via unsafe URIs]
+**Vulnerability:** The `iframe` `src` attribute in `TalkLayout.tsx` was vulnerable to XSS if `videoUrl` in the MDX frontmatter contained an unsafe URI protocol (e.g., `javascript:` or `data:`). Since `getYouTubeEmbedUrl` returned non-YouTube URLs unchanged, these URIs were injected directly into the DOM.
+**Learning:** React prevents XSS in standard element content but DOES NOT prevent XSS in `iframe` `src` or `a` `href` attributes if the provided URL uses `javascript:`. String filtering or Regex for this is often bypassable via whitespace (`   javascript:`).
+**Prevention:** Always validate URL protocols using the native `URL` constructor (e.g., `new URL(videoUrl, 'http://localhost')`) and strictly allow only secure protocols (`http:`, `https:`) or specific root-relative paths. If validation fails, safely fallback to `about:blank`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,24 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for javascript: URIs to prevent XSS', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for javascript: URIs with leading spaces', () => {
+    const url = '   javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for data: URIs', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('allows root-relative paths', () => {
+    const url = '/local-video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,24 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
+
+  // Security: Prevent XSS from javascript: or data: URIs in iframe src
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return 'about:blank';
+    }
+  } catch (e) {
+    return 'about:blank';
+  }
+
   return videoUrl;
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unvalidated URL scheme in iframe source allowed potentially malicious `javascript:` or `data:` URIs, bypassing standard React XSS protection.
🎯 **Impact:** Exploitation could allow execution of arbitrary JavaScript inside an iframe context when viewing a maliciously crafted talk post.
🔧 **Fix:** Added protocol validation in `getYouTubeEmbedUrl` using `new URL()`. Ensures only `http:`/`https:` protocols are returned and falls back to `about:blank` for unsafe inputs.
✅ **Verification:** Verified by running the new test suite in `app/db/talks.test.ts` via Vitest.

---
*PR created automatically by Jules for task [5448775559359124689](https://jules.google.com/task/5448775559359124689) started by @jreed91*