### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2024-05-24 - XSS via Unsafe Protocols in dynamically generated iframe src
+**Vulnerability:** The `getYouTubeEmbedUrl` function in `app/db/talks.ts` directly returned unvalidated `videoUrl` values for non-YouTube strings. This allowed malicious protocols like `javascript:` to be injected into the `src` attribute of `iframe` elements when rendering talk layouts.
+**Learning:** React handles basic cross-site scripting (XSS) protections in text bodies but does not validate URLs dynamically passed to sensitive attributes like `href` or `iframe src`. A specific XSS pattern for this codebase includes injecting arbitrary attributes to iframes or links using unsafe URI fallback handlers.
+**Prevention:** Always validate URLs dynamically generated for `iframe src` or `href` against an allowlist of safe protocols (`http:`, `https:`). When validating dynamic URLs, use the native `URL` constructor (`new URL(url, 'http://localhost')`) to securely extract and check the `.protocol` property, defaulting to `about:blank` on error.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,17 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('blocks javascript protocols', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('allows relative urls', () => {
+    expect(getYouTubeEmbedUrl('/local/video.mp4')).toBe('/local/video.mp4');
+  });
+
+  it('allows valid http/https urls', () => {
+    expect(getYouTubeEmbedUrl('http://example.com/video.mp4')).toBe('http://example.com/video.mp4');
+    expect(getYouTubeEmbedUrl('https://example.com/video.mp4')).toBe('https://example.com/video.mp4');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,23 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Validate fallback URLs to prevent XSS via malicious protocols
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URLs
+  }
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `getYouTubeEmbedUrl` function directly returned untrusted URLs for non-YouTube strings. This allowed malicious protocols (like `javascript:`) to be passed to an iframe's `src` attribute.
🎯 Impact: This could result in Cross-Site Scripting (XSS) when rendering iframes with user-controlled data.
🔧 Fix: Validates fallback URLs by using the native URL constructor to extract and check the `.protocol` against a safe allowlist (`http:`, `https:`), safely resolving empty or relative paths, and defaulting to `about:blank` on error. Added corresponding unit tests.
✅ Verification: Tested via unit tests for valid HTTP/HTTPS URLs, relative URLs, empty strings, and explicitly rejecting `javascript:` URLs. Run `npm run test` to verify.

---
*PR created automatically by Jules for task [12325470714802340356](https://jules.google.com/task/12325470714802340356) started by @jreed91*