### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS via unvalidated iframe src fallback

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-02-28 - [XSS via Unvalidated Iframe Fallback Source]
+**Vulnerability:** Cross-Site Scripting (XSS) and SSRF vulnerability in `TalkLayout.tsx` where an attacker could provide a malicious `javascript:` or `data:` URL in the MDX frontmatter `videoUrl` field. `getYouTubeEmbedUrl` failed to validate the URL schema for non-YouTube fallbacks, allowing arbitrary script execution when the payload was passed to the `iframe src` attribute.
+**Learning:** Fallbacks from parsed external inputs into `iframe` tags must validate URL schemes. Using the native `URL` constructor to enforce `http:`, `https:`, or root-relative paths prevents execution of `javascript:` or `data:` URIs and ensures isolation.
+**Prevention:** Always validate URL schemes (using the native `URL` constructor, not Regex) before assigning external input to potentially dangerous DOM attributes like `iframe src` or `a href`. If the scheme is invalid, fallback to `about:blank`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -35,6 +35,21 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 
+  it('returns the original URL unchanged for root-relative local paths', () => {
+    const url = '/local/video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
+
+  it('returns about:blank for malicious javascript: URLs', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for malicious data: URLs', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
   it('returns the original URL unchanged for empty string', () => {
     expect(getYouTubeEmbedUrl('')).toBe('');
   });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,22 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URLs
+  }
+  return 'about:blank';
 }


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix XSS via unvalidated iframe src fallback

**🚨 Severity:** HIGH
**💡 Vulnerability:** Cross-Site Scripting (XSS) and SSRF vulnerability where unvalidated `videoUrl` fallback strings were directly passed into an `iframe`'s `src` attribute. 
**🎯 Impact:** An attacker could craft a malicious talk/MDX file with a `javascript:` or `data:` URL as the `videoUrl`, causing the client's browser to execute arbitrary script within the context of the domain when the Talk page is rendered.
**🔧 Fix:** Updated `getYouTubeEmbedUrl` in `app/db/talks.ts` to utilize the native `URL` constructor to validate the parsed protocol. It now restricts fallbacks to `http:`, `https:`, or root-relative paths (by passing a dummy localhost base URL). Unsafe schemas fallback securely to `about:blank`.
**✅ Verification:** Added specific unit test cases in `app/db/talks.test.ts` to simulate `javascript:` and `data:` URIs, which correctly assert they return `about:blank`. Ran the test suite, linting, and build steps to ensure everything is verified and functionally sound.

---
*PR created automatically by Jules for task [14084089912214936620](https://jules.google.com/task/14084089912214936620) started by @jreed91*