### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS in iframe src URL validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2024-05-05 - XSS Vulnerability in iframe src
+**Vulnerability:** Unvalidated external URL input used in `iframe` `src` or anchor `href` attributes could contain `javascript:` or `data:` URIs, potentially leading to Cross-Site Scripting (XSS).
+**Learning:** The native `URL` constructor provides robust protocol validation, unlike string matching which can easily be bypassed by whitespace padding (e.g. `   javascript:alert(1)`).
+**Prevention:** Always validate all dynamic or external URLs used in `src` or `href` attributes to ensure they use safe protocols (`http:`, `https:`) before rendering, and fallback to safe paths (e.g., `about:blank`).

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,17 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('blocks javascript: URIs to prevent XSS', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('   javascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('blocks data: URIs', () => {
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
+  });
+
+  it('allows root-relative paths', () => {
+    expect(getYouTubeEmbedUrl('/local/video.mp4')).toBe('/local/video.mp4');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,24 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Sentinel: Prevent SSRF/XSS by validating external URL protocol
+  try {
+    const parsedUrl = new URL(videoUrl, 'http://localhost');
+    if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (error) {
+    // Ignore invalid URLs
+  }
+
+  return 'about:blank'; // Fallback for unsafe or invalid URLs
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `getYouTubeEmbedUrl` function in `app/db/talks.ts` returns the unvalidated `videoUrl` if it fails to match the YouTube regex. This unvalidated URL is then passed directly to the `src` attribute of an `iframe` in `TalkLayout.tsx`. If an attacker can inject malicious content into the MDX frontmatter (e.g., via `javascript:alert(1)`), it results in Cross-Site Scripting (XSS).
🎯 Impact: Attackers could execute arbitrary JavaScript in the context of the user's browser, potentially leading to session hijacking, defacement, or redirection to malicious sites.
🔧 Fix: Updated `getYouTubeEmbedUrl` to parse the fallback URL using the native `URL` constructor (with a safe local base to support relative paths). It now verifies that the protocol is either `http:` or `https:` and returns `about:blank` for unsafe URIs.
✅ Verification: Added comprehensive unit tests in `app/db/talks.test.ts` to ensure `javascript:` and `data:` URIs are blocked while valid absolute and root-relative paths continue to work correctly. Verified that tests pass via `npm run test`.

---
*PR created automatically by Jules for task [7829782549145009698](https://jules.google.com/task/7829782549145009698) started by @jreed91*