### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in Talk video iframe URL

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2024-05-07 - [HIGH] Fix XSS Vulnerability in Talk Video Iframe URL
+**Vulnerability:** The `getYouTubeEmbedUrl` function in `app/db/talks.ts` fell back to returning the unvalidated original string if it wasn't a YouTube URL, which allowed `javascript:` protocols to be injected into an iframe `src` attribute.
+**Learning:** Fallback URLs in `iframe` or `a` tags derived from dynamic sources (like MDX frontmatter) must be explicitly validated against an allowlist of safe protocols (like `http:` and `https:`) to prevent XSS.
+**Prevention:** Use `new URL(url, base)` to validate protocols instead of relying on regex or `startsWith`, and explicitly fallback to `'about:blank'` for invalid or unsafe protocols.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,17 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for dangerous protocols like javascript:', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert("XSS")')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('  javascript:alert("XSS")')).toBe('about:blank');
+  });
+
+  it('returns about:blank for dangerous protocols like data:', () => {
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
+  });
+
+  it('allows relative paths starting with /', () => {
+    expect(getYouTubeEmbedUrl('/local/video.mp4')).toBe('/local/video.mp4');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,24 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    // Restrict to safe protocols to prevent XSS in iframe src
+    const url = new URL(videoUrl, 'http://localhost');
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URLs
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH

💡 **Vulnerability:**
The `getYouTubeEmbedUrl` function in `app/db/talks.ts` used a fallback that returned the original string if it didn't match a YouTube URL. This string was passed directly to the `src` attribute of an `iframe` in `TalkLayout.tsx`. An attacker could inject a malicious `javascript:` URL via MDX frontmatter (e.g., `videoUrl: javascript:alert('XSS')`) causing a Cross-Site Scripting (XSS) vulnerability.

🎯 **Impact:**
If an attacker could submit or edit talk MDX files (or if they are generated dynamically from an untrusted source), they could execute arbitrary JavaScript within the context of the user's browser viewing the talk.

🔧 **Fix:**
Implemented strict protocol validation using `new URL(videoUrl, 'http://localhost')`. If the parsed URL protocol is not `http:` or `https:`, the function now safely falls back to `about:blank`.

✅ **Verification:**
Added a test suite to `app/db/talks.test.ts` validating that `javascript:` and `data:` URLs are safely mitigated. Verified via `npm run test`.

---
*PR created automatically by Jules for task [6287391350886536772](https://jules.google.com/task/6287391350886536772) started by @jreed91*