### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Denial of Service in safeJsonStringify

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+## 2025-03-03 - [Fix Denial of Service Risk in safeJsonStringify]
+**Vulnerability:** The `safeJsonStringify` utility in `app/utils/sanitize.ts` threw a TypeError when passed `undefined`, because `JSON.stringify(undefined)` returns `undefined`, which doesn't have a `.replace` method. Since this utility is used in crucial code paths like generating JSON-LD for Next.js metadata, rendering an undefined metadata object would crash the page.
+**Learning:** Utilities that chain methods on standard JavaScript functions like `JSON.stringify` must account for the full range of possible return types (e.g., string or undefined) to prevent unexpected runtime exceptions that act as DoS vulnerabilities.
+**Prevention:** Always validate or provide a safe default string (e.g., `'{}'`) when the source data can result in `undefined` output from `JSON.stringify()`.

--- a/app/utils/sanitize.test.ts
+++ b/app/utils/sanitize.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { safeJsonStringify } from './sanitize';
+
+describe('safeJsonStringify', () => {
+  it('escapes <, >, and & characters', () => {
+    const data = { html: '<script>alert("XSS & fun")</script>' };
+    const result = safeJsonStringify(data);
+    expect(result).toBe('{"html":"\\u003cscript\\u003ealert(\\"XSS \\u0026 fun\\")\\u003c/script\\u003e"}');
+  });
+
+  it('handles undefined input safely', () => {
+    expect(safeJsonStringify(undefined)).toBe('{}');
+  });
+
+  it('handles null input safely', () => {
+    expect(safeJsonStringify(null)).toBe('null');
+  });
+
+  it('handles functions safely (JSON.stringify returns undefined)', () => {
+    expect(safeJsonStringify(() => {})).toBe('{}');
+  });
+
+  it('handles regular JSON data correctly', () => {
+    const data = { name: "Test", count: 123, isTrue: true };
+    expect(safeJsonStringify(data)).toBe('{"name":"Test","count":123,"isTrue":true}');
+  });
+});

--- a/app/utils/sanitize.ts
+++ b/app/utils/sanitize.ts
@@ -3,7 +3,9 @@
  * Replaces <, >, and & with their unicode escape sequences.
  */
 export function safeJsonStringify(data: unknown): string {
-  return JSON.stringify(data)
+  const str = JSON.stringify(data);
+  if (str === undefined) return '{}';
+  return str
     .replace(/</g, '\\u003c')
     .replace(/>/g, '\\u003e')
     .replace(/&/g, '\\u0026');


### PR DESCRIPTION
Severity: MEDIUM
Vulnerability: The `safeJsonStringify` utility threw a `TypeError` when passed `undefined` because it attempted to chain `.replace()` onto `JSON.stringify(undefined)`, which returns `undefined`.
Impact: As this utility is used in crucial code paths like generating JSON-LD for Next.js metadata, rendering an undefined metadata object would crash the application or page, creating a Denial of Service risk.
Fix: Updated `safeJsonStringify` to handle `undefined` results from `JSON.stringify` safely by returning `"{}"`. Also added a unit test suite to verify this behavior for `undefined`, `null`, functions, and valid JSON. Included learnings in `.jules/sentinel.md`.
Verification: Tests in `app/utils/sanitize.test.ts` pass and the application builds successfully.

---
*PR created automatically by Jules for task [16057199635138833428](https://jules.google.com/task/16057199635138833428) started by @jreed91*