### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-05-09 - [Fix Iframe Src XSS]
+**Vulnerability:** XSS vulnerability where unvalidated user input or markdown frontmatter (e.g., `videoUrl`) could be directly interpolated into an `iframe` `src` attribute. This allows execution of arbitrary code via `javascript:` URIs.
+**Learning:** Browsers execute Javascript when `javascript:` URIs are passed to `iframe` `src` attributes. Simple regex or `startsWith` checks can be bypassed by prepending whitespaces or using different casing.
+**Prevention:** Always validate URLs meant for `iframe` `src` or external links by using the native `URL` constructor and strictly enforcing safe protocols like `http:` or `https:`. Fall back to `about:blank` for unsafe URIs.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -35,8 +35,8 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 
-  it('returns the original URL unchanged for empty string', () => {
-    expect(getYouTubeEmbedUrl('')).toBe('');
+  it('returns about:blank for empty string', () => {
+    expect(getYouTubeEmbedUrl('')).toBe('about:blank');
   });
 
   it('handles video IDs with hyphens and underscores', () => {
@@ -44,5 +44,19 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl(url)).toBe(
       'https://www.youtube.com/embed/abc-def_123'
     );
+  });
+
+  it('returns about:blank for javascript URIs to prevent XSS', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl(' javascript:alert(1)')).toBe('about:blank'); // padded
+  });
+
+  it('returns about:blank for data URIs to prevent XSS', () => {
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
+  });
+
+  it('returns the original URL unchanged for relative paths', () => {
+    const url = '/local-video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,24 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  if (!videoUrl) return 'about:blank';
+
+  try {
+    const url = new URL(videoUrl, 'http://localhost');
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      // If base was used to parse relative URLs, we should probably only return
+      // the original videoUrl if we parsed the original as http/https.
+      // But actually, for relative URLs starting with /, protocol will be http:.
+      // Let's just strictly enforce http/https protocols or root-relative URLs.
+      const isRelative = videoUrl.startsWith('/');
+      if (isRelative || url.protocol === 'http:' || url.protocol === 'https:') {
+        return videoUrl;
+      }
+    }
+  } catch (e) {
+    // Ignore error
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `getYouTubeEmbedUrl` previously reflected unvalidated fallback URLs directly. If an attacker controlled the MDX frontmatter `videoUrl` or if untrusted user input was passed, they could supply a `javascript:alert(1)` URI. This would be interpolated directly into the `src` attribute of the `iframe` in `TalkLayout`, leading to Stored Cross-Site Scripting (XSS).
🎯 Impact: Attackers could execute arbitrary Javascript in the context of the application by supplying malicious URIs.
🔧 Fix: Implemented strict URL protocol validation using the native `URL` constructor inside `getYouTubeEmbedUrl`. Only `http:` and `https:` protocols (and root-relative paths) are permitted. All other protocols, empty strings, and malformed URLs fall back to a safe `about:blank`.
✅ Verification: Added comprehensive Vitest cases for `javascript:`, `data:`, padded strings, and empty strings. Run `npm run test` or `npx vitest` to verify.

---
*PR created automatically by Jules for task [6569900212250187901](https://jules.google.com/task/6569900212250187901) started by @jreed91*