### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in YouTube embed URLs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2024-05-12 - Prevent XSS in YouTube Embed URLs
+**Vulnerability:** The `getYouTubeEmbedUrl` function returned unmodified inputs if they didn't match the YouTube regex, allowing `javascript:` and `data:` URIs to be injected via MDX frontmatter.
+**Learning:** URL fallback mechanisms must explicitly validate safe protocols (e.g. `http:`, `https:`) before returning unsanitized user-provided links, even in simple regex-based extractor functions.
+**Prevention:** Use the `URL` constructor with a safe dummy base (e.g., `new URL(url, 'http://localhost')`) to reliably parse and allowlist `.protocol` properties, defaulting to `about:blank` for unsafe protocols.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,19 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('sanitizes javascript: URIs to prevent XSS', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('sanitizes data: URIs to prevent XSS', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('allows relative paths by treating them as local URLs', () => {
+    const url = '/local/video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,22 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Prevent XSS/SSRF from unsanitized protocols (e.g. javascript:, data:)
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Fallback to safe value if URL parsing fails completely
+  }
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `getYouTubeEmbedUrl` function in `app/db/talks.ts` returned arbitrary user-provided URLs unmodified if they didn't match the expected YouTube format. This allowed XSS payloads (e.g. `javascript:alert(1)`) or SSRF via `data:` URIs injected from markdown frontmatter to bypass filters and get rendered into an `iframe` src attribute.
🎯 Impact: A malicious actor who can modify MDX content could execute arbitrary javascript on the target page.
🔧 Fix: Added protocol sanitization using the native `URL` constructor. The function now ensures the protocol is safely restricted to `http:` or `https:`, falling back to `about:blank` for dangerous protocols or malformed URLs.
✅ Verification: Tested via unit tests added to `app/db/talks.test.ts`. Run `npm run test` to execute and verify that `javascript:` and `data:` URIs are properly sanitized.

---
*PR created automatically by Jules for task [15033826729673067282](https://jules.google.com/task/15033826729673067282) started by @jreed91*