### PR TITLE
🛡️ Sentinel: [HIGH] Fix iframe XSS via unsafe URIs in getYouTubeEmbedUrl

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe XSS via Unsafe URIs]
+**Vulnerability:** XSS vulnerability where `iframe` `src` attribute derived from external user-provided or markdown metadata was not validated against unsafe URI protocols (like `javascript:` or `data:`). Empty spaces preceding the protocol could bypass simple string checks.
+**Learning:** `iframe src` can execute XSS if it resolves to a `javascript:` or `data:` protocol. Never assume markdown metadata is inherently safe. Always validate protocols robustly using the native `URL` constructor (`new URL(url, base)`) and strictly allowlist safe protocols like `http:` and `https:`.
+**Prevention:** Use `new URL(url, 'http://localhost')` to parse incoming URLs, checking `.protocol` for `http:` or `https:`, and fallback to a safe path or `about:blank` on failure or unsafe matches. Empty string URLs safely resolve to `http:` due to the base URL and can return the original empty string or be handled appropriately.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -39,6 +39,15 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl('')).toBe('');
   });
 
+  it('returns about:blank for javascript protocol URLs', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('  javascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('returns about:blank for data protocol URLs', () => {
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
+  });
+
   it('handles video IDs with hyphens and underscores', () => {
     const url = 'https://youtu.be/abc-def_123';
     expect(getYouTubeEmbedUrl(url)).toBe(

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,15 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Sentinel: XSS protection for external non-youtube links
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch {
+    return 'about:blank';
+  }
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `iframe` `src` attribute could resolve to unsafe protocols like `javascript:` or `data:` via markdown metadata, enabling Cross-Site Scripting (XSS).
🎯 Impact: Attackers could execute arbitrary JavaScript in the context of the user's browser if malicious URLs were embedded in markdown files.
🔧 Fix: Validated external non-YouTube URLs using the `URL` constructor to enforce `http:` or `https:` protocols. All other protocols fallback to `about:blank`.
✅ Verification: Tested via vitest (`app/db/talks.test.ts`) covering javascript protocol, empty URLs, and data protocols.

---
*PR created automatically by Jules for task [1816107252818765728](https://jules.google.com/task/1816107252818765728) started by @jreed91*