### PR TITLE
🛡️ Sentinel: [HIGH] Fix iframe src XSS in TalkLayout

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** XSS/SSRF vulnerability where a user-provided or malicious `videoUrl` in MDX frontmatter for talks could bypass the YouTube regex validation in `getYouTubeEmbedUrl` and be passed directly as the `src` attribute of an `iframe` in `app/components/TalkLayout.tsx`. This allowed `javascript:`, `data:`, or `vbscript:` URIs to be executed when the iframe loads.
 **Learning:** `iframe src` attributes are execution vectors for URIs. A fallback return path that simply echoes the input without strict validation enables these attacks if the primary regex doesn't match. Relying on simple string matching rather than robust URL parsing often leaves gaps for bypasses (like padded whitespace).
 **Prevention:** When falling back on a provided URL for `iframe src`, always parse the URL using the native `URL` constructor to reliably extract and check the `.protocol` property. Ensure it strictly matches safe protocols (like `http:` or `https:`) and fail securely by returning a safe default like `about:blank`.
+
+## 2025-03-03 - [Fix Stored XSS in Next.js Link href]
+**Vulnerability:** CodeQL flagged a Stored XSS vulnerability in `app/components/TalkCard.tsx` where an unencoded `talk.slug` (derived from the file system, but conceptually user-controlled) was interpolated directly into a `<Link href={...}>` tag.
+**Learning:** Next.js `Link` components do not automatically URL-encode dynamic segments passed via string interpolation to the `href` attribute. If a file name or slug somehow contains malicious characters, it could be interpreted directly.
+**Prevention:** Always sanitize dynamically generated variables that are interpolated into Next.js `<Link href={...}>` paths using `encodeURIComponent()`.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe src XSS in TalkLayout]
+**Vulnerability:** XSS/SSRF vulnerability where a user-provided or malicious `videoUrl` in MDX frontmatter for talks could bypass the YouTube regex validation in `getYouTubeEmbedUrl` and be passed directly as the `src` attribute of an `iframe` in `app/components/TalkLayout.tsx`. This allowed `javascript:`, `data:`, or `vbscript:` URIs to be executed when the iframe loads.
+**Learning:** `iframe src` attributes are execution vectors for URIs. A fallback return path that simply echoes the input without strict validation enables these attacks if the primary regex doesn't match. Relying on simple string matching rather than robust URL parsing often leaves gaps for bypasses (like padded whitespace).
+**Prevention:** When falling back on a provided URL for `iframe src`, always parse the URL using the native `URL` constructor to reliably extract and check the `.protocol` property. Ensure it strictly matches safe protocols (like `http:` or `https:`) and fail securely by returning a safe default like `about:blank`.

--- a/app/components/TalkCard.tsx
+++ b/app/components/TalkCard.tsx
@@ -1,10 +1,10 @@
-import { Talk } from 'app/db/talks';
-import Link from 'next/link';
-import { parseISO, format } from 'date-fns';
+import { Talk } from "app/db/talks";
+import Link from "next/link";
+import { parseISO, format } from "date-fns";
 
 export default function TalkCard({ talk }: { talk: Talk }) {
   return (
-    <Link href={`/talks/${talk.slug}`} className="w-full">
+    <Link href={`/talks/${encodeURIComponent(talk.slug)}`} className="w-full">
       <div className="w-full mb-8 transform hover:scale-[1.01] transition-all">
         <div className="flex flex-col justify-between md:flex-row">
           <h4 className="w-full mb-2 text-lg font-medium text-gray-900 md:text-xl dark:text-gray-100">
@@ -28,7 +28,7 @@ export default function TalkCard({ talk }: { talk: Talk }) {
           </div>
         </div>
         <div className="flex items-center gap-2 mb-2 text-sm text-gray-600 dark:text-gray-400">
-          <span>{format(parseISO(talk.metadata.date), 'MMMM dd, yyyy')}</span>
+          <span>{format(parseISO(talk.metadata.date), "MMMM dd, yyyy")}</span>
           {talk.metadata.event && (
             <>
               <span>•</span>
@@ -36,7 +36,9 @@ export default function TalkCard({ talk }: { talk: Talk }) {
             </>
           )}
         </div>
-        <p className="text-gray-600 dark:text-gray-400">{talk.metadata.summary}</p>
+        <p className="text-gray-600 dark:text-gray-400">
+          {talk.metadata.summary}
+        </p>
       </div>
     </Link>
   );

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -1,48 +1,73 @@
-import { describe, it, expect } from 'vitest';
-import { getYouTubeEmbedUrl } from './talks';
+import { describe, it, expect } from "vitest";
+import { getYouTubeEmbedUrl } from "./talks";
 
-describe('getYouTubeEmbedUrl', () => {
-  it('converts a standard youtube.com watch URL', () => {
-    const url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+describe("getYouTubeEmbedUrl", () => {
+  it("converts a standard youtube.com watch URL", () => {
+    const url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/dQw4w9WgXcQ'
+      "https://www.youtube.com/embed/dQw4w9WgXcQ",
     );
   });
 
-  it('converts a youtu.be short URL', () => {
-    const url = 'https://youtu.be/dQw4w9WgXcQ';
+  it("converts a youtu.be short URL", () => {
+    const url = "https://youtu.be/dQw4w9WgXcQ";
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/dQw4w9WgXcQ'
+      "https://www.youtube.com/embed/dQw4w9WgXcQ",
     );
   });
 
-  it('converts a youtube.com/embed URL', () => {
-    const url = 'https://www.youtube.com/embed/dQw4w9WgXcQ';
+  it("converts a youtube.com/embed URL", () => {
+    const url = "https://www.youtube.com/embed/dQw4w9WgXcQ";
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/dQw4w9WgXcQ'
+      "https://www.youtube.com/embed/dQw4w9WgXcQ",
     );
   });
 
-  it('converts a youtube.com/v/ URL', () => {
-    const url = 'https://www.youtube.com/v/dQw4w9WgXcQ';
+  it("converts a youtube.com/v/ URL", () => {
+    const url = "https://www.youtube.com/v/dQw4w9WgXcQ";
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/dQw4w9WgXcQ'
+      "https://www.youtube.com/embed/dQw4w9WgXcQ",
     );
   });
 
-  it('returns the original URL unchanged for non-YouTube URLs', () => {
-    const url = 'https://vimeo.com/123456789';
+  it("returns the original URL unchanged for non-YouTube URLs", () => {
+    const url = "https://vimeo.com/123456789";
     expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 
-  it('returns the original URL unchanged for empty string', () => {
-    expect(getYouTubeEmbedUrl('')).toBe('');
+  it("returns the original URL unchanged for empty string", () => {
+    expect(getYouTubeEmbedUrl("")).toBe("");
   });
 
-  it('handles video IDs with hyphens and underscores', () => {
-    const url = 'https://youtu.be/abc-def_123';
+  it("handles video IDs with hyphens and underscores", () => {
+    const url = "https://youtu.be/abc-def_123";
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/abc-def_123'
+      "https://www.youtube.com/embed/abc-def_123",
     );
+  });
+
+  it("returns about:blank for javascript: URIs", () => {
+    const url = "javascript:alert(1)";
+    expect(getYouTubeEmbedUrl(url)).toBe("about:blank");
+  });
+
+  it("returns about:blank for data: URIs", () => {
+    const url = "data:text/html,<html>";
+    expect(getYouTubeEmbedUrl(url)).toBe("about:blank");
+  });
+
+  it("returns about:blank for malformed javascript: URIs", () => {
+    const url = "   javascript:alert(1)";
+    expect(getYouTubeEmbedUrl(url)).toBe("about:blank");
+  });
+
+  it("returns about:blank for vbscript: URIs", () => {
+    const url = "vbscript:msgbox(1)";
+    expect(getYouTubeEmbedUrl(url)).toBe("about:blank");
+  });
+
+  it("returns original URL for relative paths", () => {
+    const url = "/local/video.mp4";
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from "fs";
+import path from "path";
 
 type TalkMetadata = {
   title: string;
@@ -20,14 +20,14 @@ function parseFrontmatter(fileContent: string) {
   let frontmatterRegex = /---\s*([\s\S]*?)\s*---/;
   let match = frontmatterRegex.exec(fileContent);
   let frontMatterBlock = match![1];
-  let content = fileContent.replace(frontmatterRegex, '').trim();
-  let frontMatterLines = frontMatterBlock.trim().split('\n');
+  let content = fileContent.replace(frontmatterRegex, "").trim();
+  let frontMatterLines = frontMatterBlock.trim().split("\n");
   let metadata: Partial<TalkMetadata> = {};
 
   frontMatterLines.forEach((line) => {
-    let [key, ...valueArr] = line.split(': ');
-    let value = valueArr.join(': ').trim();
-    value = value.replace(/^['"](.*)['"]$/, '$1'); // Remove quotes
+    let [key, ...valueArr] = line.split(": ");
+    let value = valueArr.join(": ").trim();
+    value = value.replace(/^['"](.*)['"]$/, "$1"); // Remove quotes
     metadata[key.trim() as keyof TalkMetadata] = value;
   });
 
@@ -35,11 +35,11 @@ function parseFrontmatter(fileContent: string) {
 }
 
 function getMDXFiles(dir: fs.PathLike) {
-  return fs.readdirSync(dir).filter((file) => path.extname(file) === '.mdx');
+  return fs.readdirSync(dir).filter((file) => path.extname(file) === ".mdx");
 }
 
 function readMDXFile(filePath: fs.PathOrFileDescriptor) {
-  let rawContent = fs.readFileSync(filePath, 'utf-8');
+  let rawContent = fs.readFileSync(filePath, "utf-8");
   return parseFrontmatter(rawContent);
 }
 
@@ -58,15 +58,27 @@ function getMDXData(dir: string): Talk[] {
 }
 
 export function getTalks(): Talk[] {
-  return getMDXData(path.join(process.cwd(), 'content', 'talks'));
+  return getMDXData(path.join(process.cwd(), "content", "talks"));
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return "";
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const parsed = new URL(videoUrl, "http://localhost");
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return videoUrl;
+    }
+  } catch (error) {
+    // ignore parsing errors
+  }
+
+  return "about:blank";
 }


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: XSS/SSRF via `iframe src` attribute
🎯 **Impact**: A user-provided `videoUrl` in MDX frontmatter for talks could bypass the basic regex in `getYouTubeEmbedUrl` and be passed unmodified into the `src` attribute of the iframe. This enables XSS by loading `javascript:`, `data:`, or `vbscript:` URIs.
🔧 **Fix**: Updated `getYouTubeEmbedUrl` to strictly validate the fallback URL protocol. Using the native `URL` constructor (which accurately handles padded whitespace and malformed URLs), it checks that the protocol is exactly `http:` or `https:`. It returns `about:blank` for invalid protocols.
✅ **Verification**: Run `npm run test` to verify the updated tests passing, and `npm run lint` for static validation.

---
*PR created automatically by Jules for task [8775234161417100867](https://jules.google.com/task/8775234161417100867) started by @jreed91*