### PR TITLE
🛡️ Sentinel: [HIGH] Fix iframe SSRF/XSS in getYouTubeEmbedUrl

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe SSRF/XSS in TalkLayout]
+**Vulnerability:** XSS and Server-Side Request Forgery (SSRF) vulnerability. The `getYouTubeEmbedUrl` function in `app/db/talks.ts` used the raw `videoUrl` directly as a fallback if it was not a YouTube URL. This unverified fallback was directly rendered as the `src` attribute of an `iframe` in `app/components/TalkLayout.tsx`. An attacker who can influence the frontmatter could provide `javascript:alert(1)` or a `data:` URI which executes JavaScript when the user loads the page.
+**Learning:** `iframe` `src` attributes are sensitive execution contexts that can run arbitrary code if populated with unsafe protocols like `javascript:` or `data:`. When a dynamic input is used for a URL, always validate its protocol before embedding it.
+**Prevention:** Use `new URL(url, base)` to reliably extract the protocol instead of trusting `startsWith`. If the protocol is not safe (e.g., `http:` or `https:`), use a safe fallback such as `about:blank`.

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,21 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const parsedUrl = new URL(videoUrl, 'http://localhost');
+    if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (error) {
+    // Ignore invalid URLs and return about:blank
+  }
+  return 'about:blank';
 }


### PR DESCRIPTION
This PR mitigates a critical Cross-Site Scripting (XSS) and Server-Side Request Forgery (SSRF) vulnerability inside `app/db/talks.ts`. The `getYouTubeEmbedUrl` function is used to supply the `src` attribute for an `iframe` in `app/components/TalkLayout.tsx`. Previously, if a URL did not match the YouTube regex, it blindly returned the raw string. This PR adds a secure validation check ensuring the protocol is strictly `http:` or `https:` (or defaults safely) to prevent `javascript:` and `data:` URIs from executing arbitrary code.

---
*PR created automatically by Jules for task [15111207722878566628](https://jules.google.com/task/15111207722878566628) started by @jreed91*