### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in YouTube embed URL generation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+## 2025-03-03 - [Fix iframe XSS]
+**Vulnerability:** XSS/SSRF vulnerability where a fallback `videoUrl` in `getYouTubeEmbedUrl` was inserted into an `iframe` `src` attribute without verifying the protocol, allowing execution of arbitrary code via `javascript:` or `data:` URLs.
+**Learning:** Even internal content from MDX frontmatter can be treated as a vulnerability vector. Dynamically generated `iframe` `src` attributes must validate the URL protocol using the native `URL` constructor to protect against XSS/SSRF vulnerabilities.
+**Prevention:** Always validate protocols using `new URL(url, base)` instead of regex or `startsWith`, and provide a safe default like `about:blank` for unsafe inputs.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,24 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('blocks javascript: URLs', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('blocks data: URLs', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('blocks URLs with padded javascript protocol', () => {
+    const url = '   javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('allows relative paths', () => {
+    const url = '/path/to/video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe('/path/to/video.mp4');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,17 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  if (!videoUrl) return '';
+
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URL
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unverified URL insertion into `iframe` `src` allowed execution of malicious `javascript:` or `data:` payloads via talk MDX `videoUrl` frontmatter.
🎯 **Impact:** XSS or SSRF execution if an attacker was able to commit or insert a malicious URL into the frontmatter.
🔧 **Fix:** Utilized the native `URL` constructor to validate the parsed protocol, allowing only `http:` or `https:`, with a safe fallback to `about:blank`.
✅ **Verification:** Validated via `vitest`, covering `javascript:`, padded protocols, empty strings, and `data:` URIs.

---
*PR created automatically by Jules for task [11979537095229709378](https://jules.google.com/task/11979537095229709378) started by @jreed91*