### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in TalkLayout iframe via getYouTubeEmbedUrl

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe XSS in TalkLayout via getYouTubeEmbedUrl]
+**Vulnerability:** XSS vulnerability where non-YouTube fallback URLs parsed from markdown frontmatter were directly assigned to the `src` attribute of an `<iframe>` in `TalkLayout`. By supplying a payload like `javascript:alert(1)`, arbitrary code execution could occur.
+**Learning:** Returning unvalidated input strings as a fallback URL is dangerous when interpolated into security-sensitive contexts like `<iframe>` `src` or `<a>` `href` properties.
+**Prevention:** Validate user-supplied URLs using the native `URL` constructor (e.g., `new URL(url, 'http://localhost')`) to ensure the resolved protocol is either `http:` or `https:`. If validation fails (or for malicious schemes like `javascript:`), return a safe fallback like `about:blank`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -30,12 +30,14 @@ describe('getYouTubeEmbedUrl', () => {
     );
   });
 
-  it('returns the original URL unchanged for non-YouTube URLs', () => {
+  it('returns the original URL unchanged for non-YouTube URLs over HTTP/HTTPS', () => {
     const url = 'https://vimeo.com/123456789';
     expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 
-  it('returns the original URL unchanged for empty string', () => {
+  it('safely falls back to about:blank for empty string (since it resolves to http:) or retains it if allowed', () => {
+    // Our implementation uses `new URL('', 'http://localhost')` which parses to `http:`.
+    // It returns the original empty string which is safe.
     expect(getYouTubeEmbedUrl('')).toBe('');
   });
 
@@ -44,5 +46,15 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl(url)).toBe(
       'https://www.youtube.com/embed/abc-def_123'
     );
+  });
+
+  it('returns about:blank for malicious protocols to prevent XSS', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('data:text/html,<html>')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('vbscript:msgbox("hello")')).toBe('about:blank');
+  });
+
+  it('allows relative paths (resolves to base URL protocol)', () => {
+    expect(getYouTubeEmbedUrl('/videos/local.mp4')).toBe('/videos/local.mp4');
   });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,13 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    //
+  }
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** XSS vulnerability where non-YouTube fallback URLs parsed from markdown frontmatter were directly assigned to the `src` attribute of an `<iframe>` in `TalkLayout`. If a malicious scheme (like `javascript:`) was supplied, it could execute arbitrary code when rendered.
🎯 **Impact:** An attacker could craft a malicious Markdown file where `videoUrl` uses `javascript:alert(1)`, leading to Stored XSS when the victim views the parsed page.
🔧 **Fix:** Refactored `getYouTubeEmbedUrl` in `app/db/talks.ts` to strictly validate fallback URLs using the native `URL` constructor. If the protocol is not `http:` or `https:`, it safely returns `about:blank`. Updated `app/db/talks.test.ts` to verify protocol restriction and ensure `javascript:` schemes are dropped. Added journal entry documenting the issue.
✅ **Verification:** Verified by unit tests. The `TalkLayout` relies on `getYouTubeEmbedUrl`, so sanitizing at the data parsing layer effectively sanitizes the `<iframe>` element.

---
*PR created automatically by Jules for task [1443190594506653192](https://jules.google.com/task/1443190594506653192) started by @jreed91*