### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2024-05-18 - [Prevent XSS in Iframe SRC via URL Validation]
+**Vulnerability:** The `getYouTubeEmbedUrl` function accepted arbitrary unvalidated `videoUrl` strings (like `javascript:alert(1)`) directly into `<iframe>` `src` attributes, enabling Stored XSS.
+**Learning:** `<iframe>` src attributes are vectors for executing unsafe URIs (`javascript:` and `data:`). Always parse and validate protocols explicitly using the native `URL` constructor rather than relying on loose string/Regex matching, and fall back to safe origins like `about:blank` for invalid inputs.
+**Prevention:** Always enforce allow-lists for protocols (`http:`, `https:`) and validate the base path when rendering dynamic URLs in sensitive DOM attributes like `src` or `href`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,19 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('sanitizes javascript: URLs to about:blank to prevent XSS', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('sanitizes data: URLs to about:blank to prevent XSS', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('allows root-relative URLs for local videos', () => {
+    const url = '/videos/local-talk.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,19 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Handle empty string cleanly
+  if (!videoUrl) return videoUrl;
+
+  try {
+    // Validate protocol to prevent XSS via javascript: or data: URIs
+    const url = new URL(videoUrl, 'http://localhost');
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Fall through to returning safe default
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `getYouTubeEmbedUrl` function in `app/db/talks.ts` accepted arbitrary unvalidated strings as a fallback, which were directly passed into an `<iframe>` `src` attribute. This allowed a potential Stored Cross-Site Scripting (XSS) vulnerability via `javascript:` or `data:` URIs if injected through Markdown frontmatter.
🎯 **Impact:** An attacker could execute arbitrary JavaScript in the context of the user's browser when they visit a talk page, leading to potential data exfiltration or session hijacking.
🔧 **Fix:** Refactored `getYouTubeEmbedUrl` to validate the `videoUrl` protocol. It uses the native `URL` constructor (which is naturally robust against obfuscation) to ensure only safe origins (`http:`, `https:`, or root-relative paths that resolve to `http:` locally) are returned. Unsafe or invalid URIs now correctly fall back to `about:blank`.
✅ **Verification:** Verified via updated test cases (`npm run test app/db/talks.test.ts`) that correctly assert `javascript:` and `data:` URIs result in `about:blank`.

---
*PR created automatically by Jules for task [16407230233562971800](https://jules.google.com/task/16407230233562971800) started by @jreed91*