### PR TITLE
🛡️ Sentinel: [HIGH] Fix Stored XSS in Iframe Fallback URL

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Stored XSS via Iframe Fallback URIs]
+**Vulnerability:** XSS vulnerability where untrusted user input from MDX frontmatter (`videoUrl`) was embedded directly into an `iframe` `src` attribute as a fallback in `getYouTubeEmbedUrl` inside `app/db/talks.ts` without validating the protocol. This allowed malicious payloads like `javascript:alert(1)`.
+**Learning:** Returning unvalidated input as a fallback URL is dangerous when the URL is rendered in executable contexts like `iframe src` or `a href`. Standard Regex matching may miss malformed or cleverly padded URIs.
+**Prevention:** Always validate URLs using the native `URL` constructor (with a safe base like `http://localhost` for relative paths) and explicitly check that the `.protocol` is `http:` or `https:` before returning the URL, otherwise fallback to a safe default like `about:blank`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,20 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for javascript: URIs', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('returns about:blank for data: URIs', () => {
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
+  });
+
+  it('allows valid external URLs in fallback', () => {
+    expect(getYouTubeEmbedUrl('https://example.com/video.mp4')).toBe('https://example.com/video.mp4');
+  });
+
+  it('allows valid root-relative paths in fallback', () => {
+    expect(getYouTubeEmbedUrl('/local/video.mp4')).toBe('/local/video.mp4');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,23 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const url = new URL(videoUrl, 'http://localhost');
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URL structures
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Stored XSS vulnerability due to unvalidated `videoUrl` fallback from MDX data directly rendered in an `iframe` `src` inside `TalkLayout`.
🎯 Impact: Attackers could potentially execute arbitrary code by passing `javascript:alert(1)` or similar malicious URIs into the markdown fields if the repo parses user or 3rd-party controlled MDX.
🔧 Fix: Used the native `URL` constructor to parse the fallback URL with a safe base (`http://localhost`), ensuring the `.protocol` strictly matches `http:` or `https:`. Defaults to `about:blank` for invalid or dangerous schemes.
✅ Verification: `npm run test` confirms `javascript:` and `data:` URIs fall back to `about:blank`, while valid absolute and root-relative paths work as expected.

---
*PR created automatically by Jules for task [8289741472430845935](https://jules.google.com/task/8289741472430845935) started by @jreed91*