### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in YouTube embed fallback URL

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix XSS vulnerability in iframe src]
+**Vulnerability:** XSS vulnerability where `getYouTubeEmbedUrl` in `app/db/talks.ts` used unvalidated frontmatter fallback `videoUrl` for iframe `src` rendering in `TalkLayout.tsx`, allowing `javascript:` URIs.
+**Learning:** Returning unvalidated input that goes directly into an iframe's `src` attribute allows attackers to inject `javascript:alert(1)` to execute malicious code within the iframe.
+**Prevention:** Validate the protocol of the provided URL before falling back to it for iframe `src` attributes. Only allow explicit safe protocols like `http:` and `https:`, returning `about:blank` for unsanctioned protocols.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,19 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for javascript: URIs', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for data: URIs', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns original URL for local paths', () => {
+    const url = '/local-video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,22 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const parsedUrl = new URL(videoUrl, 'http://localhost');
+    if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URLs and return safe fallback
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: The `getYouTubeEmbedUrl` fallback path returned user-controlled `videoUrl` directly without validation. This allowed attackers to provide `javascript:` or `data:` URIs, which would be injected into the `iframe` `src` attribute in `TalkLayout.tsx`, creating a Cross-Site Scripting (XSS) vulnerability.
🎯 **Impact**: If an attacker can control the frontmatter of an MDX file (e.g., via a compromised CMS or open PR), they could execute arbitrary JavaScript in the context of the user viewing the talk page.
🔧 **Fix**: Implemented validation using the `URL` constructor to verify the `.protocol`. Only `http:` and `https:` schemes are allowed to pass through as original URLs. Unsafe schemas are scrubbed and replaced with `about:blank`.
✅ **Verification**: Run `npm test app/db/talks.test.ts` which asserts `javascript:` and `data:` schemas correctly fall back to `about:blank`.

---
*PR created automatically by Jules for task [13885759123538275421](https://jules.google.com/task/13885759123538275421) started by @jreed91*