### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe src XSS in TalkLayout]
+**Vulnerability:** XSS vulnerability where `videoUrl` from frontmatter in MDX talks was directly rendered into the `src` attribute of an `iframe` in `TalkLayout.tsx` without validating the URL scheme.
+**Learning:** `iframe` `src` attributes are execution sinks. Using untrusted or user-defined URLs can result in XSS if an attacker inputs a `javascript:` or `data:text/html` payload.
+**Prevention:** Always validate URL schemes before injecting them into `src` attributes. Use `new URL(url, 'http://localhost')` to extract the `protocol` and enforce that it matches `http:` or `https:`. If validation fails, safely fallback to `about:blank`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -36,7 +36,14 @@ describe('getYouTubeEmbedUrl', () => {
   });
 
   it('returns the original URL unchanged for empty string', () => {
+    // Empty string resolves to http://localhost protocol
     expect(getYouTubeEmbedUrl('')).toBe('');
+  });
+
+  it('returns original URL for relative paths', () => {
+    // Relative paths resolve to http://localhost protocol
+    const url = '/static/video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 
   it('handles video IDs with hyphens and underscores', () => {
@@ -44,5 +51,21 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl(url)).toBe(
       'https://www.youtube.com/embed/abc-def_123'
     );
+  });
+
+  it('returns about:blank for javascript: URLs (XSS protection)', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+
+    // Case insensitivity bypass attempt
+    expect(getYouTubeEmbedUrl('JaVaScRiPt:alert(1)')).toBe('about:blank');
+
+    // Whitespace bypass attempt (new URL handles this)
+    expect(getYouTubeEmbedUrl('  javascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('returns about:blank for data: URLs (XSS protection)', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
   });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,17 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
+
+  // Prevent XSS from unsafe protocols like javascript: or data:
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return 'about:blank';
+    }
+  } catch (e) {
+    // If URL parsing fails entirely, fallback to a safe default
+    return 'about:blank';
+  }
+
   return videoUrl;
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: User-provided `videoUrl` in MDX frontmatter could inject a malicious scheme (like `javascript:` or `data:`) into the `iframe src` attribute in `TalkLayout.tsx`.
🎯 Impact: Attackers could execute arbitrary JavaScript code or load malicious content if they could supply bad Markdown URLs.
🔧 Fix: Validated the protocol of the URL using `new URL()`. Ensures only `http:` or `https:` protocols are returned (or standard relative paths). Invalid URLs fallback to `about:blank`.
✅ Verification: Added comprehensive Vitest assertions to verify `javascript:` bypass attempts and invalid inputs fallback securely while leaving legitimate URLs intact. Run `npm test` to verify.

---
*PR created automatically by Jules for task [12510952578414390560](https://jules.google.com/task/12510952578414390560) started by @jreed91*