### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS/SSRF in iframe fallback

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix SSRF/XSS in iframe src fallback]
+**Vulnerability:** XSS and SSRF vulnerability in `getYouTubeEmbedUrl` where unvalidated external URLs (like `javascript:alert(1)` or `data:text/html,...`) were returned as a fallback and directly injected into `iframe` `src` attributes.
+**Learning:** Returning unvalidated input strings directly into HTML attributes (even as fallbacks when a primary regex fails) is dangerous. If attackers can control the input string, they can inject malicious URL protocols.
+**Prevention:** Always parse and validate fallback URLs using `new URL()` to enforce a safe protocol allowlist (e.g., `http:` and `https:`) before rendering them in `src` or `href` attributes. Fall back to a safe neutral value like `about:blank` for invalid protocols.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,19 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for javascript: URLs to prevent XSS', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for padded javascript: URLs to prevent XSS', () => {
+    const url = '   javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for data: URLs to prevent XSS', () => {
+    const url = 'data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,23 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return videoUrl;
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const parsedUrl = new URL(videoUrl, 'http://localhost');
+    if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URL
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
* 🚨 Severity: HIGH
* 💡 Vulnerability: Unvalidated URL string inputs in MDX frontmatter `videoUrl` could be rendered as a fallback in `getYouTubeEmbedUrl` and returned without scheme validation. This could result in malicious payloads like `javascript:alert(1)` being embedded directly into `iframe` `src` attributes.
* 🎯 Impact: Cross-Site Scripting (XSS) / Server-Side Request Forgery (SSRF) if attackers controlled the `videoUrl` metadata.
* 🔧 Fix: Used the native `URL` constructor to enforce an allowlist of protocols (`http:` and `https:`). If an unsafe scheme is detected, safely fall back to `about:blank`.
* ✅ Verification: Tested edge cases including padded whitespaces, base64 data URIs, and XSS javascript URIs. All gracefully fall back to `about:blank`.

---
*PR created automatically by Jules for task [2551167276759070684](https://jules.google.com/task/2551167276759070684) started by @jreed91*