### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in Talk iframe source

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix Iframe XSS in TalkLayout]
+**Vulnerability:** XSS vulnerability where `getYouTubeEmbedUrl` would return malicious payloads like `javascript:alert(1)` unchanged if they did not match the YouTube regex, leading to XSS when rendered in the `<iframe>` `src` attribute within `app/components/TalkLayout.tsx`.
+**Learning:** `<iframe>` src attributes are a common XSS vector if arbitrary URLs from untrusted sources (like MDX frontmatter) are allowed. `javascript:` or `data:` URIs execute script within the context of the page if no sandboxing is implemented.
+**Prevention:** Always validate external URL inputs for iframe src attributes. Check if the parsed URL protocol strictly matches `http:` or `https:`, and fall back to `about:blank` otherwise.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,19 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for unsafe javascript: URIs', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for unsafe data: URIs', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('allows root-relative URLs by resolving them to localhost', () => {
+    const url = '/my-local-video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,18 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Security: prevent XSS via unsafe URIs in iframe src
+  if (!videoUrl) return '';
+
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Error parsing URL
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `getYouTubeEmbedUrl` function in `app/db/talks.ts` was returning unmodified URLs if they did not match a YouTube pattern. These URLs are rendered in an `<iframe>` `src` attribute in `app/components/TalkLayout.tsx`. An attacker could specify unsafe URIs like `javascript:alert(1)` in MDX frontmatter, which would execute arbitrary script contextually.
🎯 **Impact:** Stored Cross-Site Scripting (XSS). If a malicious MDX file is loaded, arbitrary code can be executed in the user's browser, potentially stealing sessions, manipulating the DOM, or redirecting to malicious sites.
🔧 **Fix:** Modified `getYouTubeEmbedUrl` to validate the `videoUrl` using the native `URL` constructor. If the URL is not a YouTube link, it is now strictly checked to ensure its protocol is either `http:` or `https:`. Unsafe URIs fall back to `about:blank`.
✅ **Verification:** Unit tests have been updated to test for `javascript:`, `data:`, and local relative paths. Verified by running `npm run test` where all 45 tests pass successfully.

---
*PR created automatically by Jules for task [2268381115642466583](https://jules.google.com/task/2268381115642466583) started by @jreed91*