### PR TITLE
🛡️ Sentinel: [HIGH] Fix Stored XSS in getYouTubeEmbedUrl

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix Stored XSS in MDX videoUrl iframe]
+**Vulnerability:** The `getYouTubeEmbedUrl` function directly returned unvalidated URLs into an `iframe` `src` attribute when the URL was not a YouTube embed. This allowed Stored XSS if MDX frontmatter contained an unsafe scheme like `videoUrl: javascript:alert(1)`.
+**Learning:** `iframe src` attributes are vulnerable to XSS execution via the `javascript:` and `data:` schemes. Falling back to an unsanitized raw string from user-controlled frontmatter bypasses standard input validations and allows attackers to execute scripts in the application context.
+**Prevention:** Always validate URL protocols dynamically interpolated into `iframe` sources using the native `URL` constructor to enforce `http:` or `https:`. Return safe fallbacks like `about:blank` for invalid or malicious schemes.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,12 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('prevents XSS by returning about:blank for javascript: protocol URLs', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('allows root-relative local paths', () => {
+    expect(getYouTubeEmbedUrl('/local-video.mp4')).toBe('/local-video.mp4');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,23 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const url = new URL(videoUrl, 'http://localhost');
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch {
+    // Ignore invalid URLs
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Stored Cross-Site Scripting (XSS) via `videoUrl` iframe src
🎯 Impact: Attackers could execute arbitrary JavaScript if malicious MDX frontmatter contains `videoUrl: javascript:...`. Since this is directly interpolated into an `iframe`'s `src` attribute, it bypasses standard string escaping mechanisms.
🔧 Fix: Used the native `URL` constructor to reliably validate the protocol of the provided URL. It now strictly enforces `http:` and `https:` schemes, safely falling back to local paths or `about:blank` for invalid/malicious protocols like `javascript:`.
✅ Verification: Ran unit tests validating XSS prevention which successfully passed. Run `npm test` locally.

---
*PR created automatically by Jules for task [17809062012183276264](https://jules.google.com/task/17809062012183276264) started by @jreed91*