### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS/SSRF via iframe src in TalkLayout

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix SSRF/XSS via Iframe Src in Talks]
+**Vulnerability:** XSS/SSRF risk in `app/db/talks.ts` where `getYouTubeEmbedUrl` returned the original unvalidated `videoUrl` directly into an `<iframe src={...}>` in `app/components/TalkLayout.tsx` if it wasn't a standard YouTube URL. This allowed malicious payloads like `javascript:alert(1)` or `data:text/html,...` to be injected via MDX frontmatter.
+**Learning:** Returning unvalidated fallbacks for embedded resources creates open pathways for executing arbitrary code inside iframes if the source data (e.g. Markdown metadata) becomes compromised.
+**Prevention:** Always validate URLs against an explicit allowlist of protocols (`http:`, `https:`, or root-relative paths via empty base handling) using the `URL` constructor before assigning them to sensitive attributes like `src` or `href`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,19 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for javascript: URLs to prevent XSS', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for data: URLs to prevent XSS', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns the original URL for relative paths', () => {
+    const url = '/local-video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe('/local-video.mp4');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,24 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Security: prevent XSS through malicious iframe src attributes (e.g. javascript:)
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URLs
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** `getYouTubeEmbedUrl` was returning unmodified URLs directly into `<iframe src={...}>` attributes if they didn't match the YouTube RegEx. This exposed an XSS/SSRF risk allowing attackers to execute arbitrary code or redirect users by feeding `javascript:`, `vbscript:`, or `data:` URIs via MDX metadata frontmatter.
🎯 **Impact:** If frontmatter was compromised or uncontrolled, an attacker could achieve arbitrary code execution within the iframe context or force SSRF.
🔧 **Fix:** Added protocol validation utilizing the built-in `URL` constructor (combined with a dummy local base). It ensures the fallback URL uses a safe protocol (`http:` or `https:`) or correctly maps root-relative URLs, while forcefully reverting dangerous protocols to `about:blank`.
✅ **Verification:** Validated that unit tests covering these injection vectors return `about:blank` and confirmed existing test suite passes perfectly.

---
*PR created automatically by Jules for task [14135155662326442170](https://jules.google.com/task/14135155662326442170) started by @jreed91*