### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS via unsafe iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-05-31 - [HIGH] XSS via Unsafe iframe src
+**Vulnerability:** The `getYouTubeEmbedUrl` function in `app/db/talks.ts` accepted arbitrary URLs as fallbacks and passed them directly to the `src` attribute of an `iframe` in `app/components/TalkLayout.tsx`. An attacker could exploit this to inject unsafe URIs like `javascript:` or `data:`, leading to a Cross-Site Scripting (XSS) vulnerability.
+**Learning:** React's native protections don't validate `iframe src` attributes against unsafe URI schemes (like `javascript:`). Any external URLs provided to iframes or links must be explicitly sanitized to ensure they use a safe protocol.
+**Prevention:** Validate protocols using the native `URL` constructor with a safe fallback base (e.g., `new URL(url, 'http://localhost')`). Ensure the parsed `.protocol` is strictly `http:` or `https:`. If the URL represents an unsafe scheme, fallback to a safe default like `about:blank`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -35,6 +35,21 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 
+  it('returns about:blank for unsafe javascript: URIs', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for unsafe data: URIs', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('allows root-relative URLs', () => {
+    const url = '/local/path/to/video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
+
   it('returns the original URL unchanged for empty string', () => {
     expect(getYouTubeEmbedUrl('')).toBe('');
   });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,18 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  if (!videoUrl) return videoUrl;
+
+  try {
+    // SECURITY: Validate URL protocol to prevent XSS via javascript: or data: URIs
+    const parsedUrl = new URL(videoUrl, 'http://localhost');
+    if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (error) {
+    // Fall through to return about:blank
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `getYouTubeEmbedUrl` function accepted arbitrary URLs as fallbacks, which were passed directly to an `iframe`'s `src` attribute. This allowed for unsafe URIs like `javascript:` or `data:`, leading to a Cross-Site Scripting (XSS) vulnerability.
🎯 Impact: An attacker could execute arbitrary JavaScript within the application's context if malicious frontmatter content is parsed.
🔧 Fix: Added protocol validation using the native `URL` constructor with a safe fallback base. If the parsed `.protocol` is not `http:` or `https:`, it safely returns `about:blank`. Added tests to ensure this behavior is verified.
✅ Verification: Ran `vitest` tests for `getYouTubeEmbedUrl` ensuring that unsafe protocols (`javascript:`, `data:`) return `about:blank`. All 45 unit tests across the repository pass.

---
*PR created automatically by Jules for task [17245072958298062066](https://jules.google.com/task/17245072958298062066) started by @jreed91*