### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in TalkLayout iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe src XSS in TalkLayout]
+**Vulnerability:** XSS vulnerability where untrusted user input from `talk.metadata.videoUrl` could be embedded in an `<iframe src="...">` without protocol validation, allowing `javascript:` payloads to execute in the context of the domain.
+**Learning:** Returning unvalidated fallback URLs from match functions (like `getYouTubeEmbedUrl`) and plugging them directly into iframe `src` attributes creates a dangerous injection vector. Even simple string fallbacks need robust validation.
+**Prevention:** Always validate protocols for dynamic `iframe` `src` properties. Use `new URL(url, 'http://localhost')` to parse inputs safely and ensure only `http:` or `https:` protocols are returned, falling back to `about:blank`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -35,8 +35,8 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 
-  it('returns the original URL unchanged for empty string', () => {
-    expect(getYouTubeEmbedUrl('')).toBe('');
+  it('returns about:blank for empty string', () => {
+    expect(getYouTubeEmbedUrl('')).toBe('about:blank');
   });
 
   it('handles video IDs with hyphens and underscores', () => {
@@ -44,5 +44,20 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl(url)).toBe(
       'https://www.youtube.com/embed/abc-def_123'
     );
+  });
+
+  it('returns about:blank for javascript: protocol to prevent XSS', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for data: protocol to prevent XSS', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('allows root-relative fallback paths', () => {
+    const url = '/local-video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe('/local-video.mp4');
   });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,17 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Sentinel: Sanitize user input to prevent XSS via iframe src (e.g. javascript:)
+  try {
+    if (videoUrl) {
+      const parsed = new URL(videoUrl, 'http://localhost');
+      if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+        return videoUrl;
+      }
+    }
+  } catch (e) {
+    // Return about:blank on invalid URLs
+  }
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unvalidated fallback values in `getYouTubeEmbedUrl` inside `app/db/talks.ts` could flow directly into the `src` attribute of an `iframe` component (`TalkLayout.tsx`). If untrusted metadata is provided, payloads with `javascript:` or `data:` protocol schemes could execute arbitrary code within the current domain.
🎯 **Impact:** XSS execution and session hijacking if maliciously crafted talks are imported/rendered.
🔧 **Fix:** Utilized native `new URL` parsing with a safe local base URL to enforce that the returned strings contain only permitted protocols (`http:` and `https:`). If an unexpected protocol is given, it safely falls back to `about:blank`.
✅ **Verification:** Unit tests passing cleanly against all edge cases (`javascript:`, `data:`, empty string, `/local.mp4`).

Kept solution perfectly scoped without heavy additional dependencies.

---
*PR created automatically by Jules for task [15505049675860861222](https://jules.google.com/task/15505049675860861222) started by @jreed91*