### PR TITLE
🛡️ Sentinel: [HIGH] Fix iframe src XSS in Talk Layouts

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe src XSS in Talk Layouts]
+**Vulnerability:** XSS/SSRF vulnerability where user-provided `videoUrl` values from talk frontmatter were directly interpolated into `iframe` `src` attributes without protocol validation. This allowed an attacker to potentially supply `javascript:` or `data:` URIs via markdown files, which would execute upon viewing the talk page.
+**Learning:** Even URLs meant to be parsed by regexes (like YouTube URLs) have a fallback path. If the regex doesn't match, returning the raw string into an `iframe` opens up XSS opportunities.
+**Prevention:** Always validate URL protocols using the native `URL` constructor (e.g., `new URL(url, 'http://localhost')`) before injecting them into `src` or `href` attributes. Ensure only `http:` and `https:` protocols are permitted, or safely fallback to `about:blank`.

--- a/app/components/TalkCard.tsx
+++ b/app/components/TalkCard.tsx
@@ -1,10 +1,10 @@
-import { Talk } from 'app/db/talks';
-import Link from 'next/link';
-import { parseISO, format } from 'date-fns';
+import { Talk } from "app/db/talks";
+import Link from "next/link";
+import { parseISO, format } from "date-fns";
 
 export default function TalkCard({ talk }: { talk: Talk }) {
   return (
-    <Link href={`/talks/${talk.slug}`} className="w-full">
+    <Link href={`/talks/${encodeURIComponent(talk.slug)}`} className="w-full">
       <div className="w-full mb-8 transform hover:scale-[1.01] transition-all">
         <div className="flex flex-col justify-between md:flex-row">
           <h4 className="w-full mb-2 text-lg font-medium text-gray-900 md:text-xl dark:text-gray-100">
@@ -28,7 +28,7 @@ export default function TalkCard({ talk }: { talk: Talk }) {
           </div>
         </div>
         <div className="flex items-center gap-2 mb-2 text-sm text-gray-600 dark:text-gray-400">
-          <span>{format(parseISO(talk.metadata.date), 'MMMM dd, yyyy')}</span>
+          <span>{format(parseISO(talk.metadata.date), "MMMM dd, yyyy")}</span>
           {talk.metadata.event && (
             <>
               <span>•</span>
@@ -36,7 +36,9 @@ export default function TalkCard({ talk }: { talk: Talk }) {
             </>
           )}
         </div>
-        <p className="text-gray-600 dark:text-gray-400">{talk.metadata.summary}</p>
+        <p className="text-gray-600 dark:text-gray-400">
+          {talk.metadata.summary}
+        </p>
       </div>
     </Link>
   );

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -1,48 +1,63 @@
-import { describe, it, expect } from 'vitest';
-import { getYouTubeEmbedUrl } from './talks';
+import { describe, it, expect } from "vitest";
+import { getYouTubeEmbedUrl } from "./talks";
 
-describe('getYouTubeEmbedUrl', () => {
-  it('converts a standard youtube.com watch URL', () => {
-    const url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+describe("getYouTubeEmbedUrl", () => {
+  it("converts a standard youtube.com watch URL", () => {
+    const url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/dQw4w9WgXcQ'
+      "https://www.youtube.com/embed/dQw4w9WgXcQ",
     );
   });
 
-  it('converts a youtu.be short URL', () => {
-    const url = 'https://youtu.be/dQw4w9WgXcQ';
+  it("converts a youtu.be short URL", () => {
+    const url = "https://youtu.be/dQw4w9WgXcQ";
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/dQw4w9WgXcQ'
+      "https://www.youtube.com/embed/dQw4w9WgXcQ",
     );
   });
 
-  it('converts a youtube.com/embed URL', () => {
-    const url = 'https://www.youtube.com/embed/dQw4w9WgXcQ';
+  it("converts a youtube.com/embed URL", () => {
+    const url = "https://www.youtube.com/embed/dQw4w9WgXcQ";
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/dQw4w9WgXcQ'
+      "https://www.youtube.com/embed/dQw4w9WgXcQ",
     );
   });
 
-  it('converts a youtube.com/v/ URL', () => {
-    const url = 'https://www.youtube.com/v/dQw4w9WgXcQ';
+  it("converts a youtube.com/v/ URL", () => {
+    const url = "https://www.youtube.com/v/dQw4w9WgXcQ";
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/dQw4w9WgXcQ'
+      "https://www.youtube.com/embed/dQw4w9WgXcQ",
     );
   });
 
-  it('returns the original URL unchanged for non-YouTube URLs', () => {
-    const url = 'https://vimeo.com/123456789';
+  it("returns the original URL unchanged for non-YouTube URLs", () => {
+    const url = "https://vimeo.com/123456789";
     expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 
-  it('returns the original URL unchanged for empty string', () => {
-    expect(getYouTubeEmbedUrl('')).toBe('');
+  it("returns the original URL unchanged for empty string", () => {
+    expect(getYouTubeEmbedUrl("")).toBe("");
   });
 
-  it('handles video IDs with hyphens and underscores', () => {
-    const url = 'https://youtu.be/abc-def_123';
+  it("handles video IDs with hyphens and underscores", () => {
+    const url = "https://youtu.be/abc-def_123";
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/abc-def_123'
+      "https://www.youtube.com/embed/abc-def_123",
     );
+  });
+
+  it("sanitizes javascript: URIs to about:blank", () => {
+    const url = "javascript:alert(1)";
+    expect(getYouTubeEmbedUrl(url)).toBe("about:blank");
+  });
+
+  it("sanitizes data: URIs to about:blank", () => {
+    const url = "data:text/html,<script>alert(1)</script>";
+    expect(getYouTubeEmbedUrl(url)).toBe("about:blank");
+  });
+
+  it("allows relative paths", () => {
+    const url = "/static/video.mp4";
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from "fs";
+import path from "path";
 
 type TalkMetadata = {
   title: string;
@@ -20,14 +20,14 @@ function parseFrontmatter(fileContent: string) {
   let frontmatterRegex = /---\s*([\s\S]*?)\s*---/;
   let match = frontmatterRegex.exec(fileContent);
   let frontMatterBlock = match![1];
-  let content = fileContent.replace(frontmatterRegex, '').trim();
-  let frontMatterLines = frontMatterBlock.trim().split('\n');
+  let content = fileContent.replace(frontmatterRegex, "").trim();
+  let frontMatterLines = frontMatterBlock.trim().split("\n");
   let metadata: Partial<TalkMetadata> = {};
 
   frontMatterLines.forEach((line) => {
-    let [key, ...valueArr] = line.split(': ');
-    let value = valueArr.join(': ').trim();
-    value = value.replace(/^['"](.*)['"]$/, '$1'); // Remove quotes
+    let [key, ...valueArr] = line.split(": ");
+    let value = valueArr.join(": ").trim();
+    value = value.replace(/^['"](.*)['"]$/, "$1"); // Remove quotes
     metadata[key.trim() as keyof TalkMetadata] = value;
   });
 
@@ -35,11 +35,11 @@ function parseFrontmatter(fileContent: string) {
 }
 
 function getMDXFiles(dir: fs.PathLike) {
-  return fs.readdirSync(dir).filter((file) => path.extname(file) === '.mdx');
+  return fs.readdirSync(dir).filter((file) => path.extname(file) === ".mdx");
 }
 
 function readMDXFile(filePath: fs.PathOrFileDescriptor) {
-  let rawContent = fs.readFileSync(filePath, 'utf-8');
+  let rawContent = fs.readFileSync(filePath, "utf-8");
   return parseFrontmatter(rawContent);
 }
 
@@ -58,15 +58,25 @@ function getMDXData(dir: string): Talk[] {
 }
 
 export function getTalks(): Talk[] {
-  return getMDXData(path.join(process.cwd(), 'content', 'talks'));
+  return getMDXData(path.join(process.cwd(), "content", "talks"));
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return "";
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const url = new URL(videoUrl, "http://localhost");
+    if (url.protocol === "http:" || url.protocol === "https:") {
+      return videoUrl;
+    }
+  } catch {}
+
+  return "about:blank";
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: User-provided video URLs from frontmatter were not adequately validated when falling back from a YouTube URL match, leading to potential XSS/SSRF via `javascript:` or `data:` URIs injected into the `iframe` `src` attribute.
🎯 Impact: Attackers could execute arbitrary javascript upon a user visiting a malicious talk page by supplying a `javascript:` payload in the `videoUrl` frontmatter field.
🔧 Fix: Used the native `URL` constructor to reliably extract and validate the `.protocol` property, returning `about:blank` if it is not an allowed protocol. Empty strings continue to return empty strings.
✅ Verification: Ensure tests pass via `npm run test`, which validates that `javascript:` and `data:` URIs return `about:blank`, while standard URLs and relative paths pass safely.

---
*PR created automatically by Jules for task [8740066952801459509](https://jules.google.com/task/8740066952801459509) started by @jreed91*