### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in Talk Layout iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe src XSS in Talk Layouts]
+**Vulnerability:** XSS vulnerability where unvalidated `videoUrl` values from MDX frontmatter were used directly in `iframe` `src` attributes in `app/components/TalkLayout.tsx` via `getYouTubeEmbedUrl`.
+**Learning:** `iframe` `src` attributes can execute Javascript if given `javascript:` URIs. Regular expressions or simple string checks can be bypassed by whitespace padding.
+**Prevention:** Use the native `URL` constructor (e.g., `new URL(url, 'http://localhost')`) to reliably extract and validate the `.protocol` property against `http:` and `https:`, returning `about:blank` for invalid URLs.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,17 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('sanitizes javascript: URIs to about:blank', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('  javascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('sanitizes data: URIs to about:blank', () => {
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
+  });
+
+  it('allows root-relative paths', () => {
+    expect(getYouTubeEmbedUrl('/my-local-video.mp4')).toBe('/my-local-video.mp4');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,17 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  if (!videoUrl) return '';
+
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URLs
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `getYouTubeEmbedUrl` would blindly pass through unvalidated URLs to `iframe` `src` attributes. This could allow an attacker to achieve XSS via `javascript:` URIs if they control the `videoUrl` in a talk's MDX frontmatter.
🎯 Impact: Attackers could execute arbitrary JavaScript in the application context.
🔧 Fix: Used the native `URL` constructor to enforce `http:` or `https:` protocols, safely returning `about:blank` for unsupported URIs. Allowlisted relative paths by using a dummy base URL.
✅ Verification: `npm run test` passes, including new tests for `javascript:`, `data:`, and whitespace-padded attacks.

---
*PR created automatically by Jules for task [4502342541834948569](https://jules.google.com/task/4502342541834948569) started by @jreed91*