### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in getYouTubeEmbedUrl

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-02-27 - Fix XSS vulnerability in getYouTubeEmbedUrl
+**Vulnerability:** XSS vulnerability in `getYouTubeEmbedUrl` where unrecognized URLs were returned as-is, allowing them to be injected into `iframe` `src` attributes. This permitted potentially dangerous protocols like `javascript:` or `data:` to execute when embedded in the talk layout.
+**Learning:** Returning unsanitized user-provided URIs into `iframe` `src` or `a` `href` tags can result in XSS execution. Regex validation should not just identify known good patterns (like YouTube URLs) but must also sanitize the fallback outputs. Using the native `URL` constructor to validate the `.protocol` property is a reliable way to verify safe URLs and avoids regex-based parsing errors or bypasses.
+**Prevention:** Always sanitize dynamically constructed or fallback URLs used in DOM injection points. Ensure that `new URL(url, base)` is utilized to parse and validate protocols like `http:` or `https:`, or enforce root-relative paths starting with `/`. If validation fails, return a safe fallback such as `about:blank`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -30,13 +30,28 @@ describe('getYouTubeEmbedUrl', () => {
     );
   });
 
-  it('returns the original URL unchanged for non-YouTube URLs', () => {
+  it('returns the original URL unchanged for non-YouTube HTTP/HTTPS URLs', () => {
     const url = 'https://vimeo.com/123456789';
     expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 
   it('returns the original URL unchanged for empty string', () => {
     expect(getYouTubeEmbedUrl('')).toBe('');
+  });
+
+  it('returns the original URL unchanged for root-relative paths', () => {
+    const url = '/my-video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
+
+  it('returns about:blank for dangerous protocols like javascript:', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for dangerous protocols like data:', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
   });
 
   it('handles video IDs with hyphens and underscores', () => {

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,16 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Safe fallback for non-YouTube URLs
+  try {
+    const url = new URL(videoUrl, 'http://localhost');
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URLs
+  }
+
+  return videoUrl.startsWith('/') || videoUrl === '' ? videoUrl : 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** An XSS vulnerability was identified in `getYouTubeEmbedUrl` (`app/db/talks.ts`), where any unrecognized URL string was returned as-is. This could allow malicious protocols like `javascript:` or `data:` to be injected into the `iframe` `src` attributes on the talks layout page if passed via MDX frontmatter.
🎯 **Impact:** If an attacker managed to provide or manipulate a talk's `videoUrl` metadata, they could execute arbitrary JavaScript in the context of the user's browser via the `iframe` `src`.
🔧 **Fix:** Implemented URL protocol validation using the native `URL` constructor. The function now ensures that unrecognized URLs use the `http:` or `https:` protocol, or are root-relative paths. If validation fails, it safely falls back to `about:blank`.
✅ **Verification:** Added test cases in `app/db/talks.test.ts` to verify that XSS payloads (e.g., `javascript:alert(1)`, `data:text/html,...`) return `about:blank`, while continuing to allow safe fallback HTTP/HTTPS URLs and root-relative paths. Run `npx vitest run` to confirm all 45 tests pass.

---
*PR created automatically by Jules for task [7759843858982060070](https://jules.google.com/task/7759843858982060070) started by @jreed91*