### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS via unsafe iframe src in TalkLayout

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix Iframe XSS via Untrusted URLs]
+**Vulnerability:** XSS vulnerability where `getYouTubeEmbedUrl` would return untrusted, unsanitized input URLs (like `javascript:` or `data:`) when rendering an `iframe`'s `src` attribute in `TalkLayout`.
+**Learning:** Returning unvalidated fallback URLs for `iframe` sources is dangerous, even if the primary use-case is a YouTube embed. Attackers could supply malicious payloads via MDX frontmatter that execute when the component mounts the iframe.
+**Prevention:** Always validate protocols of dynamically-provided URLs for `iframe` tags. Use the native `URL` constructor to enforce `http:` or `https:` protocols, or fallback to a safe default like `about:blank` or a relative path.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -5,28 +5,28 @@ describe('getYouTubeEmbedUrl', () => {
   it('converts a standard youtube.com watch URL', () => {
     const url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/dQw4w9WgXcQ'
+      'https://www.youtube.com/embed/dQw4w9WgXcQ',
     );
   });
 
   it('converts a youtu.be short URL', () => {
     const url = 'https://youtu.be/dQw4w9WgXcQ';
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/dQw4w9WgXcQ'
+      'https://www.youtube.com/embed/dQw4w9WgXcQ',
     );
   });
 
   it('converts a youtube.com/embed URL', () => {
     const url = 'https://www.youtube.com/embed/dQw4w9WgXcQ';
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/dQw4w9WgXcQ'
+      'https://www.youtube.com/embed/dQw4w9WgXcQ',
     );
   });
 
   it('converts a youtube.com/v/ URL', () => {
     const url = 'https://www.youtube.com/v/dQw4w9WgXcQ';
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/dQw4w9WgXcQ'
+      'https://www.youtube.com/embed/dQw4w9WgXcQ',
     );
   });
 
@@ -42,7 +42,17 @@ describe('getYouTubeEmbedUrl', () => {
   it('handles video IDs with hyphens and underscores', () => {
     const url = 'https://youtu.be/abc-def_123';
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/abc-def_123'
+      'https://www.youtube.com/embed/abc-def_123',
     );
+  });
+
+  it('blocks javascript URLs to prevent XSS', () => {
+    const url = 'javascript:alert("XSS")';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('blocks data URLs to prevent XSS', () => {
+    const url = 'data:text/html,<h1>XSS</h1>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
   });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,22 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URLs
+  }
+  return 'about:blank';
 }


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix XSS via unsafe iframe src in TalkLayout

🚨 Severity: HIGH
💡 Vulnerability: `getYouTubeEmbedUrl` returned the original `videoUrl` if it didn't match a YouTube regex. This value was directly injected into an `iframe`'s `src` attribute. An attacker could supply a URL like `javascript:alert(1)` to achieve XSS.
🎯 Impact: Execution of arbitrary JavaScript if malicious content is processed as a Talk's frontmatter.
🔧 Fix: Added protocol validation using the native `URL` constructor. Only `http:` and `https:` protocols (or valid relative paths via a `http://localhost` base URL fallback) are allowed. Otherwise, it defaults to `about:blank`.
✅ Verification: Ran unit tests to verify `javascript:` and `data:` URLs are correctly blocked.

---
*PR created automatically by Jules for task [2767415599793168910](https://jules.google.com/task/2767415599793168910) started by @jreed91*