### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in TalkLayout iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2024-06-10 - [XSS via iframe src in TalkLayout]
+**Vulnerability:** XSS vulnerability in `app/components/TalkLayout.tsx` where an `iframe` `src` attribute was populated using `talk.metadata.videoUrl` (via `getYouTubeEmbedUrl` fallback) without validating the URL protocol. This allowed attackers to inject `javascript:` URIs via MDX frontmatter.
+**Learning:** React does not automatically block `javascript:` or `data:` URIs in `iframe` `src` attributes. Any user-provided or externally sourced URL used as an `href` or `src` must be validated to ensure it uses a safe protocol (`http:` or `https:`, or safe relative paths).
+**Prevention:** Use the native `URL` constructor (e.g., `new URL(url, 'http://localhost')`) to reliably extract and validate the `.protocol` property of the URL before using it in sensitive attributes. Fallback to `about:blank` for invalid protocols.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,19 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for javascript: URLs to prevent XSS', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for data: URLs to prevent XSS', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns original URL for relative paths', () => {
+    const url = '/static/video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,14 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const url = new URL(videoUrl, 'http://localhost');
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      return videoUrl;
+    }
+    return 'about:blank';
+  } catch {
+    return 'about:blank';
+  }
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** XSS vulnerability via MDX frontmatter in `app/components/TalkLayout.tsx`. If a malicious `javascript:` URI was provided as `videoUrl`, it would be injected directly into the `iframe` `src` attribute.
🎯 **Impact:** If an attacker can control the MDX frontmatter, they could execute arbitrary JavaScript within the application context.
🔧 **Fix:** Updated `getYouTubeEmbedUrl` in `app/db/talks.ts` to use the native `URL` constructor to validate the `.protocol` of the fallback URL. It now strictly enforces `http:` or `https:` protocols (and allows safe relative URLs due to resolving against a safe base domain), falling back to `about:blank` for anything else.
✅ **Verification:** Verified by unit tests added to `app/db/talks.test.ts`. Verified by running `npm run test` ensuring all tests pass.

---
*PR created automatically by Jules for task [10676060986305468970](https://jules.google.com/task/10676060986305468970) started by @jreed91*