### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe src XSS in TalkLayout]
+**Vulnerability:** XSS vulnerability in `TalkLayout` where the `src` attribute of the `<iframe>` tag was directly mapped from `getYouTubeEmbedUrl` without validating the URL protocol. This allowed malicious payloads like `javascript:alert(1)` to be passed into the videoUrl from MDX files and execute JavaScript when the page loads or users interact with the iframe.
+**Learning:** Fallbacks from regex parsing for external resources like `src` or `href` should validate the protocols to prevent XSS payloads using `javascript:` or `data:`. The native `URL` constructor (`new URL(url, base)`) is the most reliable way to validate protocols.
+**Prevention:** Always parse untrusted or externally-sourced URLs through `new URL` and explicitly check `url.protocol === 'http:' || url.protocol === 'https:'` before injecting them into `src` or `href` attributes, using a safe fallback like `about:blank` for invalid URLs.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,14 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for unsafe protocols like javascript:', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for invalid URLs', () => {
+    const url = 'http://foo:bar:baz';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,22 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const url = new URL(videoUrl, 'http://localhost');
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch {
+    // Ignore invalid URLs
+  }
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** XSS vulnerability in `TalkLayout` where the `src` attribute of the `<iframe>` tag was directly mapped from `getYouTubeEmbedUrl` without validating the URL protocol. This allowed malicious payloads like `javascript:alert(1)` to be passed into the videoUrl from MDX files and execute JavaScript.
🎯 **Impact:** An attacker could execute arbitrary JavaScript in the context of the site if they can control the `videoUrl` in the frontmatter of a talk's MDX file.
🔧 **Fix:** Uses the native `URL` constructor to validate that only `http:` and `https:` protocols are allowed, returning `about:blank` for unsafe protocols.
✅ **Verification:** Added test cases to `app/db/talks.test.ts` to ensure `javascript:alert(1)` and invalid URLs return `about:blank`. Verified all tests pass.

---
*PR created automatically by Jules for task [10310871480135353349](https://jules.google.com/task/10310871480135353349) started by @jreed91*