### PR TITLE
🛡️ Sentinel: [HIGH] Fix iframe src XSS in getYouTubeEmbedUrl

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe src XSS in getYouTubeEmbedUrl]
+**Vulnerability:** XSS vulnerability where untrusted user input from talk frontmatter (`videoUrl`) was used as the `src` attribute for an `iframe` in `app/components/TalkLayout.tsx` via `getYouTubeEmbedUrl` in `app/db/talks.ts` without protocol validation.
+**Learning:** React/Next.js assumes strings used in `iframe` `src` attributes are safe if they look like URLs. Without validating the URL scheme, an attacker could supply `javascript:alert(1)` or `data:text/html,...` to execute arbitrary code within the context of the domain.
+**Prevention:** Always validate dynamically generated `iframe` `src` attributes or external links against an allowlist of safe protocols (e.g., `http:`, `https:`). Using the `new URL(url, base)` constructor is a reliable way to extract and check the protocol property. Fall back to a safe URI like `about:blank` for invalid protocols.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,19 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for malicious javascript URLs', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for malicious data URLs', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('allows root-relative URLs', () => {
+    const url = '/local.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,17 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  if (!videoUrl) return '';
+
+  try {
+    const parsedUrl = new URL(videoUrl, 'http://localhost');
+    if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (error) {
+    // Invalid URL structure
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: The `getYouTubeEmbedUrl` function in `app/db/talks.ts` falls back to returning the provided URL as-is when it doesn't match the YouTube video regex. If a malicious user controlled the talk markdown frontmatter (`videoUrl`), they could inject dangerous URI schemes such as `javascript:alert(1)` or `data:text/html,...` which would be directly executed when embedded within the `iframe`'s `src` attribute in `TalkLayout.tsx`.
🎯 **Impact**: Allowed execution of arbitrary JavaScript within the domain context if markdown frontmatter data was untrusted or compromised (Stored XSS).
🔧 **Fix**: Added proper URL parsing utilizing the native `URL` constructor with a localhost base. The fallback URL is now validated to ensure its scheme is exclusively `http:` or `https:`. Invalid or dangerous schemes are safely neutralized to `about:blank`.
✅ **Verification**: Run `npm run test` to verify the XSS protection logic handles both `javascript:` and `data:` schemes, and preserves legitimate absolute and relative paths.

---
*PR created automatically by Jules for task [15669600249710749053](https://jules.google.com/task/15669600249710749053) started by @jreed91*