### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix iframe src XSS vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe XSS]
+**Vulnerability:** XSS vulnerability where untrusted user input from MDX frontmatter `videoUrl` could bypass the YouTube regex check in `getYouTubeEmbedUrl` and fallback directly into an `iframe src` attribute in `app/components/TalkLayout.tsx`. This allowed unsafe protocols like `javascript:alert(1)` or `data:text/html,<script>alert(1)</script>` to be executed.
+**Learning:** React safely handles strings in text content, but attributes like `href` or `src` require their own protocol-level validation if they can be influenced by malicious content.
+**Prevention:** Always validate URLs that flow into sensitive attributes (like `src`, `href`) to ensure they use a safe protocol (`http:` or `https:`) using the native `URL` constructor (`new URL(url, 'http://localhost')`), returning a safe fallback (e.g. `'about:blank'`) if validation fails.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -35,8 +35,13 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 
+  it('blocks unsafe protocols like javascript:', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
+  });
+
   it('returns the original URL unchanged for empty string', () => {
-    expect(getYouTubeEmbedUrl('')).toBe('');
+    expect(getYouTubeEmbedUrl('')).toBe('about:blank');
   });
 
   it('handles video IDs with hyphens and underscores', () => {

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,16 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Security check: validate fallback URL protocol to prevent XSS via iframe src
+  try {
+    const url = new URL(videoUrl, 'http://localhost');
+    if ((url.protocol === 'http:' || url.protocol === 'https:') && videoUrl !== '') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore URL parsing errors and fall through to block
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: MDX frontmatter `videoUrl` could bypass the YouTube regex check in `getYouTubeEmbedUrl` and fallback directly into an `iframe src` attribute in `app/components/TalkLayout.tsx`. This allowed unsafe protocols like `javascript:alert(1)` to be executed.
🎯 Impact: Attackers could inject arbitrary JavaScript execution via XSS if malicious or poorly formatted content makes it into the frontmatter.
🔧 Fix: Validated the fallback URL protocol to ensure it only allows `http:` or `https:`, returning `'about:blank'` if an unsafe protocol or empty string is provided. Used `new URL` to reliably parse and check `.protocol`.
✅ Verification: Tested via unit tests, checked against `javascript:` payload. Tests pass. Added corresponding entry to `sentinel.md`.

---
*PR created automatically by Jules for task [4345198974668538451](https://jules.google.com/task/4345198974668538451) started by @jreed91*