### PR TITLE
🛡️ Sentinel: [HIGH] Fix iframe XSS vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix Iframe XSS]
+**Vulnerability:** XSS/SSRF via unsanitized iframe src attributes in `TalkLayout.tsx`. External/non-YouTube URLs in talk metadata (`videoUrl`) were passed unvalidated to the iframe, allowing execution of `javascript:` or injection via `data:` URLs.
+**Learning:** React safely handles general text, but attributes like `src` on `iframe` or `href` on `a` tags are sensitive to the URL's protocol. Simply bypassing YouTube regex isn't enough; fallback cases must be checked.
+**Prevention:** Always validate external URLs used in `iframe src` or `a href` by parsing them (e.g. `new URL(url, base)`) and ensuring the `protocol` is restricted to safe options like `http:` and `https:`, falling back to `about:blank` otherwise.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -35,6 +35,16 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 
+  it('returns about:blank for dangerous javascript: URLs', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for dangerous data: URLs', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
   it('returns the original URL unchanged for empty string', () => {
     expect(getYouTubeEmbedUrl('')).toBe('');
   });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,22 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return videoUrl;
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URLs
+  }
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: XSS/SSRF via unsanitized iframe src attributes.
🎯 Impact: A maliciously crafted `videoUrl` (like `javascript:alert(1)`) in a Talk's MDX could lead to arbitrary JavaScript execution in the context of the user's browser via the iframe source.
🔧 Fix: Used the native URL constructor to validate the `protocol` of the provided URL. It now strictly allows `http:` and `https:` schemes for fallback non-YouTube links, rejecting all others (e.g. `javascript:`, `data:`) to `about:blank`.
✅ Verification: Ran `vitest` tests covering `javascript:`, `data:`, empty strings, and normal valid URLs to ensure correct behavior.

---
*PR created automatically by Jules for task [5695344422929151622](https://jules.google.com/task/5695344422929151622) started by @jreed91*