### PR TITLE
🛡️ Sentinel: [HIGH] Fix iframe src XSS vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe src XSS in Talks]
+**Vulnerability:** XSS vulnerability where unvalidated `videoUrl` values from MDX frontmatter were directly assigned to an `iframe`'s `src` attribute in `app/components/TalkLayout.tsx` without proper protocol validation.
+**Learning:** Even internal content sources like markdown frontmatter can be an attack vector (e.g. from contributors or dynamic ingestion) if rendered into sensitive attributes like `src` or `href`. If a user injects `javascript:alert(1)`, the script will execute in the user's browser.
+**Prevention:** Always validate URLs using the `URL` constructor to ensure they use a safe protocol (e.g., `http:` or `https:`) before using them in `iframe` or dynamic anchors. Unsafe payloads should be rejected or fallback to `about:blank`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,14 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('falls back to about:blank for javascript: URIs to prevent XSS', () => {
+    const url = 'javascript:alert("XSS")';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('falls back to about:blank for data: URIs', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,16 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Security enhancement: Validate URL protocol to prevent XSS (e.g. javascript:)
+  try {
+    const parsedUrl = new URL(videoUrl, 'http://localhost');
+    if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // If URL parsing fails entirely, return about:blank as a safe fallback
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: XSS via unvalidated `videoUrl` frontmatter fields rendered into the `iframe` `src` attribute. A malicious user could inject `javascript:alert(1)` if they control or contribute to the markdown files.
🎯 Impact: An attacker could execute arbitrary JavaScript within the context of the user's session if a malicious payload is added to the `videoUrl` field and a user views the talk page.
🔧 Fix: Validated the URL protocol using the native `URL` constructor inside `getYouTubeEmbedUrl` in `app/db/talks.ts`, strictly allowing `http:` and `https:`. Unsafe URIs gracefully fallback to `about:blank`.
✅ Verification: Ran `npm test` verifying new unit tests explicitly block `javascript:` and `data:` URIs while successfully allowing normal links, relative paths, and empty strings.

---
*PR created automatically by Jules for task [6514597632318842303](https://jules.google.com/task/6514597632318842303) started by @jreed91*