### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS in Talk iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix Iframe SSRF / XSS in TalkLayout]
+**Vulnerability:** XSS vulnerability where `videoUrl` read from markdown frontmatter could be an unsafe URI (like `javascript:alert(1)`) and gets injected directly into the `src` attribute of an `iframe` component via `getYouTubeEmbedUrl` in `TalkLayout.tsx`.
+**Learning:** React/Next.js assumes strings inside iframe `src` are safe as long as they are plain strings. Unvalidated markdown frontmatter values bypass normal react safety checks.
+**Prevention:** Always validate protocols of external URLs using the native `URL` constructor before setting them as an iframe `src` to ensure they are `http:` or `https:`, returning a safe default like `about:blank` for invalid protocols.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -39,6 +39,11 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl('')).toBe('');
   });
 
+  it('blocks unsafe protocols like javascript: and data:', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('data:text/html,<html>')).toBe('about:blank');
+  });
+
   it('handles video IDs with hyphens and underscores', () => {
     const url = 'https://youtu.be/abc-def_123';
     expect(getYouTubeEmbedUrl(url)).toBe(

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,16 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
+
+  // Prevent XSS from javascript: or data: URIs in iframe src
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return 'about:blank';
+    }
+  } catch {
+    return 'about:blank';
+  }
+
   return videoUrl;
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Markdown frontmatter `videoUrl` for Talks was not validated when rendered as the `src` of an `iframe` in `TalkLayout.tsx`. An attacker could create a `.mdx` file with `videoUrl: javascript:alert(1)`, executing arbitrary code in the context of the domain when the page loads. 
🎯 Impact: High risk of Cross-Site Scripting (XSS) if users or compromised accounts contribute markdown content containing malicious URIs.
🔧 Fix: Updated `getYouTubeEmbedUrl` in `app/db/talks.ts` to instantiate a native `URL` object and validate that the `.protocol` is either `http:` or `https:`. Unsafe protocols correctly fall back to `about:blank`.
✅ Verification: Ran unit tests `npx vitest run app/db/talks.test.ts` to confirm functionality. Tests now specifically verify rejection of `javascript:` and `data:` URIs and successful rendering of `http:` ones. All 43 tests pass.

---
*PR created automatically by Jules for task [14492998273120869113](https://jules.google.com/task/14492998273120869113) started by @jreed91*