### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS in getYouTubeEmbedUrl

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2024-05-24 - [XSS via Fallback URLs in iframe src]
+**Vulnerability:** The `getYouTubeEmbedUrl` function in `app/db/talks.ts` falls back to returning the provided URL unchanged if it does not match a YouTube pattern. This fallback URL is directly injected into an `iframe`'s `src` attribute in `TalkLayout.tsx`. An attacker could exploit this by providing a `javascript:` or `data:` URI in the MDX frontmatter, leading to Cross-Site Scripting (XSS) when the `iframe` is rendered.
+**Learning:** React does not natively sanitize string props passed to potentially dangerous HTML attributes like `iframe` `src`. Fallback mechanisms must strictly validate output types and enforce safe protocols before injection.
+**Prevention:** Always validate protocols of external URLs using the native `URL` constructor before injecting them into `iframe` `src` or `<Link href>` attributes. Use a whitelist approach (e.g., enforcing `http:` or `https:`) and fall back to safe defaults like `about:blank` for invalid inputs. Avoid RegEx for protocol validation.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -39,6 +39,16 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl('')).toBe('');
   });
 
+  it('returns about:blank for javascript: URIs', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for data: URIs', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
   it('handles video IDs with hyphens and underscores', () => {
     const url = 'https://youtu.be/abc-def_123';
     expect(getYouTubeEmbedUrl(url)).toBe(

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,13 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
+  try {
+    const url = new URL(videoUrl, 'http://localhost');
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return 'about:blank';
+    }
+  } catch (e) {
+    return 'about:blank';
+  }
   return videoUrl;
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `getYouTubeEmbedUrl` function in `app/db/talks.ts` used an unsafe fallback, returning the raw provided URL if it didn't match a YouTube regex. Since this URL is injected directly into an `iframe src` attribute in `TalkLayout`, an attacker could provide a `javascript:` or `data:` URI in a Markdown file's frontmatter, leading to Cross-Site Scripting (XSS).
🎯 **Impact:** XSS execution on the talk page, allowing an attacker to execute arbitrary scripts in the context of the domain.
🔧 **Fix:** Replaced the unsafe raw return with strict validation using the native `URL` constructor. The function now ensures the protocol is either `http:` or `https:`. Unsafe or unparseable URLs fall back safely to `about:blank`. Added unit tests for `javascript:` and `data:` URIs.
✅ **Verification:** Run `npm run test` and observe that `app/db/talks.test.ts` passes, confirming `javascript:` and `data:` URIs result in `about:blank`.

---
*PR created automatically by Jules for task [9632755263356823300](https://jules.google.com/task/9632755263356823300) started by @jreed91*