### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-05 - [Fix iframe src XSS via videoUrl]
+**Vulnerability:** XSS vulnerability where user-provided `videoUrl` from frontmatter was passed directly into an `iframe`'s `src` attribute without validating the URL protocol in `app/components/TalkLayout.tsx` (via `getYouTubeEmbedUrl`).
+**Learning:** Next.js and React do not natively sanitize `iframe` `src` attributes. Attackers can provide a malicious URI like `javascript:alert(1)` which executes directly when the iframe loads.
+**Prevention:** Always validate protocols using the native `URL` constructor to enforce `http:` or `https:`, returning a safe fallback like `about:blank` for invalid or unsafe protocols.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -39,6 +39,21 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl('')).toBe('');
   });
 
+  it('returns about:blank for malicious javascript: URIs', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for malicious data: URIs', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns original URL for valid https: URIs', () => {
+    const url = 'https://example.com/video';
+    expect(getYouTubeEmbedUrl(url)).toBe('https://example.com/video');
+  });
+
   it('handles video IDs with hyphens and underscores', () => {
     const url = 'https://youtu.be/abc-def_123';
     expect(getYouTubeEmbedUrl(url)).toBe(

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,15 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
+
+  try {
+    const parsedUrl = new URL(videoUrl, 'http://localhost');
+    if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+      return 'about:blank';
+    }
+  } catch (e) {
+    return 'about:blank';
+  }
+
   return videoUrl;
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Cross-Site Scripting (XSS) vulnerability via user-provided `videoUrl` in MDX frontmatter. The `getYouTubeEmbedUrl` function was passing unrecognized URLs directly into the `iframe`'s `src` attribute in `TalkLayout.tsx` without validation. If a malicious user was able to inject a `javascript:` or `data:` URI, the browser would execute it immediately upon loading the iframe.
🎯 **Impact:** Potential for arbitrary code execution if user data or compromised MDX content enters the `videoUrl` field.
🔧 **Fix:** Updated `getYouTubeEmbedUrl` to enforce an allowlist of protocols (`http:` and `https:`) using the native `URL` constructor. Unsafe URLs now gracefully fall back to `'about:blank'`.
✅ **Verification:** Added dedicated unit tests to `app/db/talks.test.ts` to prove `javascript:` and `data:` URIs are neutralized. Passed `npm run test`, `npm run lint`, and `npm run build`.

---
*PR created automatically by Jules for task [15842458735968874572](https://jules.google.com/task/15842458735968874572) started by @jreed91*