### PR TITLE
🛡️ Sentinel: [HIGH] Fix iframe protocol XSS in talks page

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix Iframe XSS via Invalid Protocol]
+**Vulnerability:** XSS/SSRF vulnerability where user-supplied fallback URLs (e.g., `videoUrl` in MDX frontmatter) were directly injected into `<iframe>` `src` attributes without protocol validation if they didn't match the standard YouTube regex. This allowed injection of `javascript:` or `data:` URIs.
+**Learning:** React and Next.js do not natively sanitize strings passed to `iframe` `src` attributes. Regex checks can often be bypassed by padding (e.g. ` javascript:alert(1)`).
+**Prevention:** Always use the native `URL` constructor (e.g., `new URL(url, 'http://localhost')`) to reliably parse and validate the `.protocol` property (e.g., ensuring `http:` or `https:`) before rendering external links or dynamic iframe sources.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,17 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('sanitizes javascript: URIs to about:blank', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+
+    const paddedUrl = ' javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(paddedUrl)).toBe('about:blank');
+  });
+
+  it('sanitizes data: URIs to about:blank', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,16 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Security enhancement: Prevent XSS from javascript: or data: URIs in iframes
+  try {
+    const url = new URL(videoUrl, 'http://localhost');
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Fall back for unparseable URLs
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `app/components/TalkLayout.tsx` used `getYouTubeEmbedUrl` to supply an `iframe` `src`. If the markdown `videoUrl` fell back to returning the original URL, it was injected directly without validating the protocol. A malicious payload like `javascript:alert(1)` could execute arbitrary JS.
🎯 Impact: Exploitation could allow an attacker to bypass Next.js protections and achieve XSS within the context of the user's browser, potentially leading to session hijacking or unauthorized actions.
🔧 Fix: Updated `app/db/talks.ts` to construct a new `URL` relative to `http://localhost`. Verified that `url.protocol` is either `http:` or `https:`. If the protocol is invalid (e.g. `javascript:`, `data:`, `vbscript:`), it falls back to `about:blank`.
✅ Verification: Ran `vitest` with newly added edge cases in `app/db/talks.test.ts` testing for `javascript:` and space-padded ` javascript:` evasions. Verified `.jules/sentinel.md` journal update and clean test run.

---
*PR created automatically by Jules for task [1838350219562119542](https://jules.google.com/task/1838350219562119542) started by @jreed91*