### PR TITLE
🛡️ Sentinel: [HIGH] Fix iframe XSS vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe src XSS in TalkLayout]
+**Vulnerability:** XSS vulnerability where untrusted user input from an MDX file (`videoUrl`) was passed directly into an `iframe`'s `src` attribute without protocol validation.
+**Learning:** `iframe` `src` attributes do not automatically sanitize `javascript:` or `data:` URIs. It is critical to enforce `http:` or `https:` protocols using a `URL` parser before rendering user-provided URLs in these attributes.
+**Prevention:** Always parse and validate protocols for URLs destined for `iframe` `src` attributes or `a` `href`s using `new URL(url, base)` to ensure they use safe protocols.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,14 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('sanitizes javascript: URLs to about:blank', () => {
+    const url = 'javascript:alert("XSS")';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('sanitizes data: URLs to about:blank', () => {
+    const url = 'data:text/html,<script>alert("XSS")</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,22 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const url = new URL(videoUrl, 'http://localhost');
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URLs
+  }
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `TalkLayout` component renders an `iframe` for video embeds using URLs sourced from MDX frontmatter (`videoUrl`). The fallback logic in `getYouTubeEmbedUrl` returned any unrecognized string as-is. This could lead to XSS if an attacker injected a `javascript:` or `data:` URI into the MDX file, as `iframe` `src` attributes do not inherently sanitize these.
🎯 Impact: If exploited, an attacker could execute arbitrary JavaScript within the context of the user's session when they visit the compromised talk page.
🔧 Fix: Updated `getYouTubeEmbedUrl` in `app/db/talks.ts` to parse the URL using the `URL` constructor (with a `http://localhost` base for relative paths). It now strictly enforces that the protocol is either `http:` or `https:`. If it is anything else (or invalid), it returns `about:blank`. Tests were added in `app/db/talks.test.ts` to verify `javascript:` and `data:` URIs are properly blocked.
✅ Verification: Ensure tests pass (`npx vitest run`). Review the test cases asserting `javascript:alert("XSS")` is converted to `about:blank`.

---
*PR created automatically by Jules for task [6650583155599665808](https://jules.google.com/task/6650583155599665808) started by @jreed91*