### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix XSS in iframe src attribute

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe src XSS]
+**Vulnerability:** XSS/SSRF vulnerability where user-provided `videoUrl` in `getYouTubeEmbedUrl` was not validated when it didn't match the YouTube regex, allowing malicious URLs (e.g. `javascript:alert(1)`) to be passed directly to the `iframe` `src` attribute.
+**Learning:** `iframe` `src` attributes are susceptible to `javascript:` and `data:` URI attacks. React/Next.js does not sanitize these values automatically. When using native `URL` constructors to validate URLs, empty strings fallback correctly as root-relative URLs, but invalid protocols must be strictly filtered or sanitized.
+**Prevention:** Always validate protocols (e.g., ensuring `http:` or `https:`) of external URLs using the native `URL` constructor before injection into `iframe` `src` to prevent XSS vulnerabilities from `javascript:` or `data:` URIs.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,14 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('sanitizes javascript: URLs to about:blank to prevent XSS', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('sanitizes data: URLs to about:blank to prevent XSS', () => {
+    const url = 'data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,24 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return videoUrl;
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
+
+  // Validate protocol to prevent XSS (javascript:, data:) or SSRF
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return 'about:blank';
+    }
+  } catch (e) {
+    return 'about:blank';
+  }
+
   return videoUrl;
 }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL/HIGH
💡 **Vulnerability:** XSS/SSRF vulnerability where user-provided `videoUrl` in `getYouTubeEmbedUrl` was not validated when it didn't match the YouTube regex, allowing malicious URLs (e.g. `javascript:alert(1)`) to be passed directly to the `iframe` `src` attribute.
🎯 **Impact:** If an attacker gains control over a talk's metadata (e.g., via a compromised MDX file or dynamic input), they could inject malicious `javascript:` or `data:` URIs into the `iframe` `src`, leading to cross-site scripting (XSS) and potentially executing arbitrary code in the user's browser.
🔧 **Fix:** Implemented protocol validation using the native `URL` constructor. The fallback URL must now strictly use the `http:` or `https:` protocol. Any invalid protocol is safely replaced with `about:blank`.
✅ **Verification:** Unit tests have been added in `app/db/talks.test.ts` to ensure that `javascript:` and `data:` URLs are properly sanitized to `about:blank`. To verify, run `npm run test app/db/talks.test.ts`.

---
*PR created automatically by Jules for task [16420820087454789038](https://jules.google.com/task/16420820087454789038) started by @jreed91*