### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe embed URL

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix Iframe XSS via Unsafe Protocols]
+**Vulnerability:** XSS vulnerability in `getYouTubeEmbedUrl` (`app/db/talks.ts`) where unrecognized external links fell back to returning the raw string. This could allow execution of `javascript:` or `data:` URIs if injected into the `src` attribute of an iframe.
+**Learning:** Next.js and React do not natively sanitize or block `javascript:` URIs passed dynamically to iframe `src` or standard anchor `href` tags.
+**Prevention:** Always validate external URL protocols using the native `URL` constructor (which reliably normalizes padded strings) to ensure they are `http:` or `https:` before rendering them into HTML attributes. Default unsafe paths to `about:blank`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,24 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for javascript: URIs to prevent XSS', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('  javascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('returns about:blank for data: URIs to prevent XSS', () => {
+    expect(getYouTubeEmbedUrl('data:text/html,<html>')).toBe('about:blank');
+  });
+
+  it('allows http: and https: protocols', () => {
+    expect(getYouTubeEmbedUrl('http://example.com/video')).toBe('http://example.com/video');
+    expect(getYouTubeEmbedUrl('https://example.com/video')).toBe('https://example.com/video');
+  });
+
+  it('returns original url for valid root-relative paths', () => {
+    // using new URL(url, base) where url='' resolves to the base URL and inherits its protocol 'http:'
+    // and '/local-video.mp4' will resolve to 'http://localhost/local-video.mp4'
+    expect(getYouTubeEmbedUrl('/local-video.mp4')).toBe('/local-video.mp4');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,24 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return videoUrl;
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Security: Prevent XSS via unsafe URIs in iframe src
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URLs
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Cross-Site Scripting (XSS) could occur if a malicious URL (like `javascript:alert(1)`) was provided in a Talk's metadata for the video embed, as it fell back to directly rendering the string in an iframe `src` attribute.
🎯 **Impact:** An attacker could execute arbitrary JavaScript within the context of the user's session if they could inject malicious content into the video URL metadata.
🔧 **Fix:** Added protocol validation using the native `URL` constructor inside `getYouTubeEmbedUrl`. It now explicitly checks that protocols are either `http:` or `https:`. Unsafe or malformed URIs (such as `javascript:` or `data:`) fall back securely to `about:blank`.
✅ **Verification:** Unit tests have been added to verify that standard URLs pass through properly, and unsafe protocols return `about:blank`. Run tests via `npx vitest run app/db/talks.test.ts`.

---
*PR created automatically by Jules for task [508881065847479937](https://jules.google.com/task/508881065847479937) started by @jreed91*