### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS in iframe src via malicious talk metadata

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe XSS via malicious videoUrl]
+**Vulnerability:** XSS vulnerability where untrusted `videoUrl` from frontmatter in MDX talk files was used as the fallback `src` in an `iframe` in `app/components/TalkLayout.tsx` without validating the URL protocol. This allowed execution of `javascript:` or `data:` URIs if provided as the `videoUrl`.
+**Learning:** `iframe` `src` attributes are a prime target for XSS and must always be validated to ensure they use a secure protocol (`http:` or `https:`), or gracefully default to a safe value like `about:blank`.
+**Prevention:** Use the `URL` constructor (e.g. `new URL(url, 'http://localhost')`) to safely parse untrusted URLs before assigning them to dynamic properties like `iframe src` or `a href`. Regex checking or `startsWith` validation can be bypassed.

--- a/app/components/TalkCard.tsx
+++ b/app/components/TalkCard.tsx
@@ -4,7 +4,7 @@ import { parseISO, format } from 'date-fns';
 
 export default function TalkCard({ talk }: { talk: Talk }) {
   return (
-    <Link href={`/talks/${talk.slug}`} className="w-full">
+    <Link href={`/talks/${encodeURIComponent(talk.slug)}`} className="w-full">
       <div className="w-full mb-8 transform hover:scale-[1.01] transition-all">
         <div className="flex flex-col justify-between md:flex-row">
           <h4 className="w-full mb-2 text-lg font-medium text-gray-900 md:text-xl dark:text-gray-100">

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -1,48 +1,59 @@
-import { describe, it, expect } from 'vitest';
-import { getYouTubeEmbedUrl } from './talks';
+import { describe, it, expect } from "vitest";
+import { getYouTubeEmbedUrl } from "./talks";
 
-describe('getYouTubeEmbedUrl', () => {
-  it('converts a standard youtube.com watch URL', () => {
-    const url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+describe("getYouTubeEmbedUrl", () => {
+  it("converts a standard youtube.com watch URL", () => {
+    const url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/dQw4w9WgXcQ'
+      "https://www.youtube.com/embed/dQw4w9WgXcQ",
     );
   });
 
-  it('converts a youtu.be short URL', () => {
-    const url = 'https://youtu.be/dQw4w9WgXcQ';
+  it("converts a youtu.be short URL", () => {
+    const url = "https://youtu.be/dQw4w9WgXcQ";
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/dQw4w9WgXcQ'
+      "https://www.youtube.com/embed/dQw4w9WgXcQ",
     );
   });
 
-  it('converts a youtube.com/embed URL', () => {
-    const url = 'https://www.youtube.com/embed/dQw4w9WgXcQ';
+  it("converts a youtube.com/embed URL", () => {
+    const url = "https://www.youtube.com/embed/dQw4w9WgXcQ";
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/dQw4w9WgXcQ'
+      "https://www.youtube.com/embed/dQw4w9WgXcQ",
     );
   });
 
-  it('converts a youtube.com/v/ URL', () => {
-    const url = 'https://www.youtube.com/v/dQw4w9WgXcQ';
+  it("converts a youtube.com/v/ URL", () => {
+    const url = "https://www.youtube.com/v/dQw4w9WgXcQ";
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/dQw4w9WgXcQ'
+      "https://www.youtube.com/embed/dQw4w9WgXcQ",
     );
   });
 
-  it('returns the original URL unchanged for non-YouTube URLs', () => {
-    const url = 'https://vimeo.com/123456789';
+  it("returns the original URL unchanged for non-YouTube URLs", () => {
+    const url = "https://vimeo.com/123456789";
     expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 
-  it('returns the original URL unchanged for empty string', () => {
-    expect(getYouTubeEmbedUrl('')).toBe('');
+  it("returns the original URL unchanged for empty string", () => {
+    expect(getYouTubeEmbedUrl("")).toBe("");
   });
 
-  it('handles video IDs with hyphens and underscores', () => {
-    const url = 'https://youtu.be/abc-def_123';
+  it("handles video IDs with hyphens and underscores", () => {
+    const url = "https://youtu.be/abc-def_123";
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/abc-def_123'
+      "https://www.youtube.com/embed/abc-def_123",
+    );
+  });
+
+  it("returns about:blank for javascript: URIs to prevent XSS", () => {
+    expect(getYouTubeEmbedUrl("javascript:alert(1)")).toBe("about:blank");
+    expect(getYouTubeEmbedUrl("  javascript:alert(1)")).toBe("about:blank");
+  });
+
+  it("returns about:blank for data: URIs to prevent XSS", () => {
+    expect(getYouTubeEmbedUrl("data:text/html,<script>alert(1)</script>")).toBe(
+      "about:blank",
     );
   });
 });

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -1,59 +1,57 @@
-import { describe, it, expect } from "vitest";
-import { getYouTubeEmbedUrl } from "./talks";
+import { describe, it, expect } from 'vitest';
+import { getYouTubeEmbedUrl } from './talks';
 
-describe("getYouTubeEmbedUrl", () => {
-  it("converts a standard youtube.com watch URL", () => {
-    const url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+describe('getYouTubeEmbedUrl', () => {
+  it('converts a standard youtube.com watch URL', () => {
+    const url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
     expect(getYouTubeEmbedUrl(url)).toBe(
-      "https://www.youtube.com/embed/dQw4w9WgXcQ",
+      'https://www.youtube.com/embed/dQw4w9WgXcQ'
     );
   });
 
-  it("converts a youtu.be short URL", () => {
-    const url = "https://youtu.be/dQw4w9WgXcQ";
+  it('converts a youtu.be short URL', () => {
+    const url = 'https://youtu.be/dQw4w9WgXcQ';
     expect(getYouTubeEmbedUrl(url)).toBe(
-      "https://www.youtube.com/embed/dQw4w9WgXcQ",
+      'https://www.youtube.com/embed/dQw4w9WgXcQ'
     );
   });
 
-  it("converts a youtube.com/embed URL", () => {
-    const url = "https://www.youtube.com/embed/dQw4w9WgXcQ";
+  it('converts a youtube.com/embed URL', () => {
+    const url = 'https://www.youtube.com/embed/dQw4w9WgXcQ';
     expect(getYouTubeEmbedUrl(url)).toBe(
-      "https://www.youtube.com/embed/dQw4w9WgXcQ",
+      'https://www.youtube.com/embed/dQw4w9WgXcQ'
     );
   });
 
-  it("converts a youtube.com/v/ URL", () => {
-    const url = "https://www.youtube.com/v/dQw4w9WgXcQ";
+  it('converts a youtube.com/v/ URL', () => {
+    const url = 'https://www.youtube.com/v/dQw4w9WgXcQ';
     expect(getYouTubeEmbedUrl(url)).toBe(
-      "https://www.youtube.com/embed/dQw4w9WgXcQ",
+      'https://www.youtube.com/embed/dQw4w9WgXcQ'
     );
   });
 
-  it("returns the original URL unchanged for non-YouTube URLs", () => {
-    const url = "https://vimeo.com/123456789";
+  it('returns the original URL unchanged for non-YouTube URLs', () => {
+    const url = 'https://vimeo.com/123456789';
     expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 
-  it("returns the original URL unchanged for empty string", () => {
-    expect(getYouTubeEmbedUrl("")).toBe("");
+  it('returns the original URL unchanged for empty string', () => {
+    expect(getYouTubeEmbedUrl('')).toBe('');
   });
 
-  it("handles video IDs with hyphens and underscores", () => {
-    const url = "https://youtu.be/abc-def_123";
+  it('handles video IDs with hyphens and underscores', () => {
+    const url = 'https://youtu.be/abc-def_123';
     expect(getYouTubeEmbedUrl(url)).toBe(
-      "https://www.youtube.com/embed/abc-def_123",
+      'https://www.youtube.com/embed/abc-def_123'
     );
   });
 
-  it("returns about:blank for javascript: URIs to prevent XSS", () => {
-    expect(getYouTubeEmbedUrl("javascript:alert(1)")).toBe("about:blank");
-    expect(getYouTubeEmbedUrl("  javascript:alert(1)")).toBe("about:blank");
+  it('returns about:blank for javascript: URIs to prevent XSS', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('  javascript:alert(1)')).toBe('about:blank');
   });
 
-  it("returns about:blank for data: URIs to prevent XSS", () => {
-    expect(getYouTubeEmbedUrl("data:text/html,<script>alert(1)</script>")).toBe(
-      "about:blank",
-    );
+  it('returns about:blank for data: URIs to prevent XSS', () => {
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
   });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from 'fs';
+import path from 'path';
 
 type TalkMetadata = {
   title: string;
@@ -20,14 +20,14 @@ function parseFrontmatter(fileContent: string) {
   let frontmatterRegex = /---\s*([\s\S]*?)\s*---/;
   let match = frontmatterRegex.exec(fileContent);
   let frontMatterBlock = match![1];
-  let content = fileContent.replace(frontmatterRegex, "").trim();
-  let frontMatterLines = frontMatterBlock.trim().split("\n");
+  let content = fileContent.replace(frontmatterRegex, '').trim();
+  let frontMatterLines = frontMatterBlock.trim().split('\n');
   let metadata: Partial<TalkMetadata> = {};
 
   frontMatterLines.forEach((line) => {
-    let [key, ...valueArr] = line.split(": ");
-    let value = valueArr.join(": ").trim();
-    value = value.replace(/^['"](.*)['"]$/, "$1"); // Remove quotes
+    let [key, ...valueArr] = line.split(': ');
+    let value = valueArr.join(': ').trim();
+    value = value.replace(/^['"](.*)['"]$/, '$1'); // Remove quotes
     metadata[key.trim() as keyof TalkMetadata] = value;
   });
 
@@ -35,11 +35,11 @@ function parseFrontmatter(fileContent: string) {
 }
 
 function getMDXFiles(dir: fs.PathLike) {
-  return fs.readdirSync(dir).filter((file) => path.extname(file) === ".mdx");
+  return fs.readdirSync(dir).filter((file) => path.extname(file) === '.mdx');
 }
 
 function readMDXFile(filePath: fs.PathOrFileDescriptor) {
-  let rawContent = fs.readFileSync(filePath, "utf-8");
+  let rawContent = fs.readFileSync(filePath, 'utf-8');
   return parseFrontmatter(rawContent);
 }
 
@@ -58,7 +58,7 @@ function getMDXData(dir: string): Talk[] {
 }
 
 export function getTalks(): Talk[] {
-  return getMDXData(path.join(process.cwd(), "content", "talks"));
+  return getMDXData(path.join(process.cwd(), 'content', 'talks'));
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
@@ -74,12 +74,12 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   // Security: Prevent XSS by validating non-YouTube fallback URLs
   // Only allow http/https protocols to prevent javascript: or data: URI execution in iframes
   try {
-    const parsed = new URL(videoUrl, "http://localhost");
-    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
       return videoUrl;
     }
-  } catch (e) {
+  } catch (_e) {
     // Ignore invalid URLs
   }
-  return "about:blank";
+  return 'about:blank';
 }

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from "fs";
+import path from "path";
 
 type TalkMetadata = {
   title: string;
@@ -20,14 +20,14 @@ function parseFrontmatter(fileContent: string) {
   let frontmatterRegex = /---\s*([\s\S]*?)\s*---/;
   let match = frontmatterRegex.exec(fileContent);
   let frontMatterBlock = match![1];
-  let content = fileContent.replace(frontmatterRegex, '').trim();
-  let frontMatterLines = frontMatterBlock.trim().split('\n');
+  let content = fileContent.replace(frontmatterRegex, "").trim();
+  let frontMatterLines = frontMatterBlock.trim().split("\n");
   let metadata: Partial<TalkMetadata> = {};
 
   frontMatterLines.forEach((line) => {
-    let [key, ...valueArr] = line.split(': ');
-    let value = valueArr.join(': ').trim();
-    value = value.replace(/^['"](.*)['"]$/, '$1'); // Remove quotes
+    let [key, ...valueArr] = line.split(": ");
+    let value = valueArr.join(": ").trim();
+    value = value.replace(/^['"](.*)['"]$/, "$1"); // Remove quotes
     metadata[key.trim() as keyof TalkMetadata] = value;
   });
 
@@ -35,11 +35,11 @@ function parseFrontmatter(fileContent: string) {
 }
 
 function getMDXFiles(dir: fs.PathLike) {
-  return fs.readdirSync(dir).filter((file) => path.extname(file) === '.mdx');
+  return fs.readdirSync(dir).filter((file) => path.extname(file) === ".mdx");
 }
 
 function readMDXFile(filePath: fs.PathOrFileDescriptor) {
-  let rawContent = fs.readFileSync(filePath, 'utf-8');
+  let rawContent = fs.readFileSync(filePath, "utf-8");
   return parseFrontmatter(rawContent);
 }
 
@@ -58,15 +58,28 @@ function getMDXData(dir: string): Talk[] {
 }
 
 export function getTalks(): Talk[] {
-  return getMDXData(path.join(process.cwd(), 'content', 'talks'));
+  return getMDXData(path.join(process.cwd(), "content", "talks"));
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return videoUrl;
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Security: Prevent XSS by validating non-YouTube fallback URLs
+  // Only allow http/https protocols to prevent javascript: or data: URI execution in iframes
+  try {
+    const parsed = new URL(videoUrl, "http://localhost");
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URLs
+  }
+  return "about:blank";
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** XSS vulnerability where untrusted `videoUrl` from frontmatter in MDX talk files was used as the fallback `src` in an `iframe` in `app/components/TalkLayout.tsx` without validating the URL protocol.
🎯 **Impact:** If an attacker can inject malicious content into the MDX talk metadata (or if a user is tricked into clicking a link rendered with this metadata), they could execute arbitrary code via `javascript:` or `data:` URIs if provided as the `videoUrl`.
🔧 **Fix:** Updated `getYouTubeEmbedUrl` in `app/db/talks.ts` to use the `URL` constructor to safely parse untrusted fallback URLs and enforce `http:` or `https:` protocols, defaulting to `about:blank` for unsafe protocols. Added security unit tests to `app/db/talks.test.ts` to assert that malicious protocols are rejected.
✅ **Verification:** Run `npm run test` to verify that `getYouTubeEmbedUrl` tests pass. Check `.jules/sentinel.md` for the updated Sentinel journal entry.

---
*PR created automatically by Jules for task [8398802710232279455](https://jules.google.com/task/8398802710232279455) started by @jreed91*