### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in YouTube embed URLs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2024-06-28 - [High] Prevent XSS in YouTube Embed URLs
+**Vulnerability:** The `getYouTubeEmbedUrl` function in `app/db/talks.ts` accepted raw input and returned it unchanged if it didn't match the YouTube video regex. When this output was fed directly into an `iframe src` attribute in `TalkLayout.tsx`, it allowed for potentially executing `javascript:` or `data:` URIs, leading to Cross-Site Scripting (XSS).
+**Learning:** Even fallback outputs from regex parser functions can act as injection vectors when passed into dangerous sinks like `iframe src`. We should explicitly validate the protocol of the final output. The native `URL` constructor with a safe localhost base handles checking both absolute and relative URLs robustly.
+**Prevention:** Use `new URL(url, 'http://localhost')` to extract the `.protocol` property and ensure it is strictly `http:` or `https:`. Return a safe fallback like `about:blank` otherwise.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -30,7 +30,7 @@ describe('getYouTubeEmbedUrl', () => {
     );
   });
 
-  it('returns the original URL unchanged for non-YouTube URLs', () => {
+  it('returns the original URL unchanged for non-YouTube URLs with safe protocol', () => {
     const url = 'https://vimeo.com/123456789';
     expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
@@ -44,5 +44,20 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl(url)).toBe(
       'https://www.youtube.com/embed/abc-def_123'
     );
+  });
+
+  it('returns about:blank for javascript: URIs', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for data: URIs', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns root relative path because base url is local so http: protocol', () => {
+    const url = '/foo/bar';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,25 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
+  let finalUrl = videoUrl;
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
-    return `https://www.youtube.com/embed/${match[1]}`;
+    finalUrl = `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const urlObj = new URL(finalUrl, 'http://localhost');
+    if (urlObj.protocol === 'http:' || urlObj.protocol === 'https:') {
+      return finalUrl;
+    }
+  } catch (e) {
+    // If parsing fails, fall back to safe default
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `getYouTubeEmbedUrl` function in `app/db/talks.ts` used a regex to parse YouTube URLs, but if it didn't match, it returned the raw input. This output was passed directly into an `iframe src` attribute in `TalkLayout.tsx`. An attacker could inject `javascript:` or `data:` URIs via the `videoUrl` frontmatter field in MDX files, leading to Stored Cross-Site Scripting (XSS).
🎯 Impact: If malicious content is injected, executing arbitrary JavaScript in the context of the user's session when they view the talk page.
🔧 Fix: Wrapped the final URL output in the native `URL` constructor with a safe localhost base. Explicitly validated the `.protocol` property to ensure it is only `http:` or `https:`. If the parse fails or the protocol is unsafe, it gracefully falls back to `about:blank`. Added comprehensive Vitest cases.
✅ Verification: Ran `npm run test -- --run` to ensure all tests, including new malicious protocol edge cases, pass successfully.

---
*PR created automatically by Jules for task [11750102230332542847](https://jules.google.com/task/11750102230332542847) started by @jreed91*