### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe src attribute

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+## 2025-03-03 - [Fix XSS in iframe src attribute]
+**Vulnerability:** XSS vulnerability where standard unsanitized string values (e.g. `videoUrl` fallback in MDX frontmatter) were injected directly into an `iframe` `src` attribute via `getYouTubeEmbedUrl`.
+**Learning:** External links sourced from user-provided content or MDX frontmatter can contain unsafe URIs like `javascript:` or `data:`, bypassing validation entirely if relying strictly on Regex meant for specific host matching (like YouTube). React natively protects `href` tags but does not sanitize strings passed to `iframe` `src`.
+**Prevention:** Validate protocols of external URLs using the native `URL` constructor (e.g. `new URL(url, 'http://localhost')`). Enforce `http:` or `https:`, and safely fall back to `about:blank` for unsafe URIs.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,18 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for unsafe protocols like javascript:', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('   javascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('returns about:blank for unsafe protocols like data:', () => {
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
+  });
+
+  it('returns the original URL for root relative paths', () => {
+    const url = '/local/video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,19 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  if (!videoUrl) {
+    return videoUrl;
+  }
+
+  try {
+    const url = new URL(videoUrl, 'http://localhost');
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Invalid URL fallback
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unsanitized string values from MDX frontmatter (`videoUrl`) were injected directly into `iframe` `src` attributes, allowing for potential XSS via `javascript:` or `data:` URIs that bypassed the initial YouTube Regex.
🎯 **Impact:** If malicious frontmatter or user-provided data was processed, an attacker could execute arbitrary JavaScript within the context of the application by forcing the iframe to load an unsafe protocol.
🔧 **Fix:** Updated `getYouTubeEmbedUrl` to parse the input URL using the native `URL` constructor, explicitly enforcing `http:` or `https:` protocols and safely falling back to `about:blank` for any unsafe or malformed URIs.
✅ **Verification:** Added comprehensive test cases in `app/db/talks.test.ts` verifying that `javascript:` and `data:` URIs are neutralized to `about:blank`, while legitimate protocols and paths remain functional.

---
*PR created automatically by Jules for task [2714096078217671454](https://jules.google.com/task/2714096078217671454) started by @jreed91*