### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe src XSS in Talk Layouts]
+**Vulnerability:** XSS/SSRF vulnerability where user-provided `videoUrl` from MDX frontmatter was directly embedded into `iframe` `src` attributes without protocol validation if it didn't match the YouTube regex. This could allow execution of `javascript:` or `data:` URIs.
+**Learning:** `iframe` `src` attributes are sensitive sinks. Even if a field is expected to be a standard URL (like a YouTube video link), it's essential to enforce strict protocol validation (e.g., `http:` or `https:`) because dynamic content sources (like MDX files) can be easily manipulated to include malicious payloads.
+**Prevention:** Always validate protocols using the native `URL` constructor before injecting dynamic URLs into sensitive attributes like `src` or `href`. Fallback to `about:blank` or relative safe paths for non-matching protocols.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,10 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('sanitizes unsafe protocols like javascript: and data:', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('vbscript:msgbox(1)')).toBe('about:blank');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,15 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
+
+  try {
+    const url = new URL(videoUrl, 'http://localhost');
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return 'about:blank';
+    }
+  } catch {
+    return 'about:blank';
+  }
+
   return videoUrl;
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** XSS/SSRF vulnerability where user-provided `videoUrl` from MDX frontmatter was directly embedded into `iframe` `src` attributes without protocol validation if it didn't match the YouTube regex. This could allow execution of `javascript:` or `data:` URIs.
🎯 **Impact:** If a malicious URL is added to the MDX content, it could execute arbitrary JavaScript within the context of the domain when a user visits the talk page, or perform unauthorized SSRF requests.
🔧 **Fix:** Added validation using the native `URL` constructor to enforce `http:` or `https:` protocols. If an unsafe protocol is detected or the URL is malformed, it safely falls back to `about:blank`.
✅ **Verification:** Added test cases to `app/db/talks.test.ts` and ran the full Vitest suite to ensure all tests pass.

---
*PR created automatically by Jules for task [14059107261329833649](https://jules.google.com/task/14059107261329833649) started by @jreed91*