### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS via Unsafe Protocols in Markdown Frontmatter

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2024-07-02 - [XSS via Unsafe Protocols in Markdown Frontmatter]
+**Vulnerability:** Found a Cross-Site Scripting (XSS) vulnerability in `getYouTubeEmbedUrl` where an attacker could provide `javascript:` or `data:` URLs in a markdown file's frontmatter `videoUrl` field, which was then directly rendered into an iframe's `src` attribute.
+**Learning:** React/Next.js do not natively sanitize iframe `src` attributes against unsafe URI protocols (`javascript:`, `data:`). Because this app parses markdown frontmatter directly into React props without intermediate sanitization, any URL fields must be explicitly validated before rendering.
+**Prevention:** Use the native `URL` constructor (e.g., `new URL(url, 'http://localhost')`) to reliably extract and check the `.protocol` property. Ensure valid protocols (e.g., `http:`, `https:`) before using the URL in `href` or `src` attributes, falling back to `about:blank` for unsafe protocols.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,19 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for javascript: URLs to prevent XSS', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for data: URLs to prevent XSS', () => {
+    const url = 'data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns the original URL for relative paths', () => {
+    const url = '/local/video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,23 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // URL Validation to prevent XSS via unsafe protocols in iframe src
+  try {
+    const parsedUrl = new URL(videoUrl, 'http://localhost');
+    if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+      return videoUrl;
+    }
+    return 'about:blank';
+  } catch {
+    return 'about:blank';
+  }
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `getYouTubeEmbedUrl` in `app/db/talks.ts` permitted any markdown frontmatter `videoUrl` directly into the returned string if it didn't match the YouTube regex. This was directly rendered as an `iframe`'s `src` attribute in `TalkLayout.tsx`, allowing Cross-Site Scripting (XSS) via unsafe protocols like `javascript:` or `data:`.
🎯 Impact: Attackers could execute arbitrary code if they injected malicious links into the talks' markdown data.
🔧 Fix: Used the native `URL` constructor to reliably validate that the returned fallback URL strictly uses `http:` or `https:`. Unsafe URIs gracefully fallback to `about:blank`.
✅ Verification: Added unit tests ensuring safe fallback for `javascript:` and `data:` URLs, while allowing standard HTTP/HTTPS links and properly resolving relative local paths.

---
*PR created automatically by Jules for task [1041835726112007730](https://jules.google.com/task/1041835726112007730) started by @jreed91*