### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS and DoS vulnerabilities

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,13 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-02-27 - [XSS via javascript: URIs in getYouTubeEmbedUrl]
+**Vulnerability:** XSS vulnerability in dynamically generated iframe src attributes where unsanitized user input (via MDX frontmatter) could contain javascript: or data: URIs, leading to execution of arbitrary scripts.
+**Learning:** React/Next.js iframe src attributes are not natively sanitized against unsafe protocols. A fallback URL in getYouTubeEmbedUrl allowed arbitrary URIs.
+**Prevention:** Always validate URL protocols for dynamic iframe src attributes or external links sourced from user input. Use the native URL constructor (e.g., new URL(url, 'http://localhost')) to parse and verify the protocol.
+
+## 2025-02-27 - [TypeError DoS via JSON.stringify in safeJsonStringify]
+**Vulnerability:** A DoS vulnerability where passing undefined (or unstringifiable values like functions) to safeJsonStringify resulted in JSON.stringify returning undefined, causing a TypeError when .replace() was subsequently called.
+**Learning:** JSON.stringify can return undefined. Blindly chaining methods on its output can cause application crashes (Denial of Service).
+**Prevention:** Explicitly check if the result of JSON.stringify is truthy (or specifically undefined) before performing operations like .replace().

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,16 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Security enhancement: Validate protocol to prevent XSS via javascript: or data: URIs
+  try {
+    const parsedUrl = new URL(videoUrl, 'http://localhost');
+    if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // URL parsing failed
+  }
+
+  return 'about:blank';
 }

--- a/app/utils/sanitize.ts
+++ b/app/utils/sanitize.ts
@@ -3,7 +3,11 @@
  * Replaces <, >, and & with their unicode escape sequences.
  */
 export function safeJsonStringify(data: unknown): string {
-  return JSON.stringify(data)
+  const stringified = JSON.stringify(data);
+  // Security enhancement: Prevent TypeError DoS crashes if data is undefined or functions
+  if (!stringified) return 'null';
+
+  return stringified
     .replace(/</g, '\\u003c')
     .replace(/>/g, '\\u003e')
     .replace(/&/g, '\\u0026');


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** 
1. **XSS via `javascript:` URIs:** The `getYouTubeEmbedUrl` function contained a fallback that would return the provided `videoUrl` directly if it didn't match the YouTube regex. When this URL is used as an `iframe` `src` attribute (e.g., in MDX frontmatter), passing a `javascript:` or `data:` URI could lead to Cross-Site Scripting (XSS).
2. **TypeError DoS in `safeJsonStringify`:** If `safeJsonStringify` was passed `undefined` (or non-stringifiable values like functions), `JSON.stringify` returned `undefined`. The function then blindly chained `.replace()`, causing a `TypeError` application crash (Denial of Service).

🎯 **Impact:** 
1. Arbitrary script execution if malicious URIs are provided in frontmatter data.
2. Application crashes (DoS) when encountering unexpected JSON serialization results.

🔧 **Fix:**
1. Added protocol validation using the native `URL` constructor in `getYouTubeEmbedUrl`. Only `http:` and `https:` protocols (and implicitly valid relative paths due to the `http://localhost` base URL) are permitted. Unsafe protocols now safely fall back to `about:blank`.
2. Updated `safeJsonStringify` to explicitly check if `JSON.stringify` returns a truthy value (or specifically check for `undefined`). It now safely returns `'null'` instead of crashing when serialization fails.

✅ **Verification:**
1. Unit tests pass cleanly via `npx vitest --run`.
2. Tested the new `safeJsonStringify` implementation to ensure `undefined` now gracefully returns `'null'` instead of throwing a `TypeError`.

---
*PR created automatically by Jules for task [14561470626639321143](https://jules.google.com/task/14561470626639321143) started by @jreed91*