### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+## 2024-05-15 - XSS Vulnerability in iframe src
+**Vulnerability:** The `getYouTubeEmbedUrl` function in `app/db/talks.ts` returned the raw `videoUrl` if it wasn't a YouTube URL, which was then directly embedded into an `iframe`'s `src` attribute in `app/components/TalkLayout.tsx`. This allowed execution of arbitrary code via `javascript:` or `data:` URIs.
+**Learning:** React and Next.js do not natively sanitize strings passed to `iframe` `src` attributes. Dynamic `iframe` `src` values need explicit protocol validation to prevent Cross-Site Scripting (XSS).
+**Prevention:** Always validate protocols (e.g., ensuring `http:` or `https:`) of external URLs using the native `URL` constructor before injection to prevent XSS vulnerabilities from `javascript:` or `data:` URIs.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,19 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('sanitizes javascript: URIs to about:blank', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('sanitizes data: URIs to about:blank', () => {
+    const url = 'data:text/html,<html>XSS</html>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('allows relative paths by defaulting to base http://localhost', () => {
+    const url = '/static/video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe('/static/video.mp4');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,24 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return videoUrl;
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
+
+  try {
+    // Prevent XSS by validating the protocol of the fallback URL
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return 'about:blank';
+    }
+  } catch (e) {
+    return 'about:blank';
+  }
+
   return videoUrl;
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `getYouTubeEmbedUrl` function returned raw, unvalidated `videoUrl`s for non-YouTube links. These were injected directly into an `iframe`'s `src` attribute, allowing XSS execution via `javascript:` or `data:` URIs.
🎯 Impact: Attackers could potentially craft malicious MDX content that executes arbitrary JavaScript when the page is viewed.
🔧 Fix: Added protocol validation using the native `URL` constructor. If a protocol other than `http:` or `https:` is detected, it safely falls back to `about:blank`.
✅ Verification: Ensure tests pass via `npm run test` or check the new unit tests verifying that `javascript:` and `data:` URIs are correctly sanitized.

---
*PR created automatically by Jules for task [4915268901955670542](https://jules.google.com/task/4915268901955670542) started by @jreed91*