### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe src XSS]
+**Vulnerability:** XSS vulnerability where user-provided or external URLs (`metadata.videoUrl`) were injected directly into an `iframe` `src` attribute without sanitization, allowing execution of malicious scripts via `javascript:` or `data:` URIs.
+**Learning:** React and Next.js do not natively sanitize strings passed to `iframe` `src` attributes. A seemingly benign video URL field can be exploited if an attacker provides a `javascript:` URI.
+**Prevention:** Always validate protocols (e.g., ensuring `http:` or `https:`) of external URLs using the native `URL` constructor before injection to prevent XSS vulnerabilities from `javascript:` or `data:` URIs.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,14 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for javascript: URIs', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for data: URIs', () => {
+    const url = 'data:text/html,<html>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,23 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URLs
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unvalidated user-controlled input (`videoUrl` from frontmatter) was directly interpolated into an iframe's `src` attribute. An attacker could provide a malicious `javascript:` or `data:` URI which, when embedded and rendered in the `TalkLayout` iframe, could execute arbitrary code.
🎯 **Impact:** Allows Stored Cross-Site Scripting (XSS) if untrusted data is injected via talk metadata.
🔧 **Fix:** Added protocol validation using the native `URL` object in `getYouTubeEmbedUrl`. The updated logic strictly permits `http:` and `https:` protocols, effectively sanitizing any potentially dangerous URIs and returning `about:blank` for unsafe data.
✅ **Verification:** Unit tests have been added in `talks.test.ts` to ensure `javascript:` and `data:` URIs are properly blocked and result in `about:blank`. The entire vitest suite passes successfully. Added findings to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [4077898466177260595](https://jules.google.com/task/4077898466177260595) started by @jreed91*