### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS in iframe URL fallback

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## $(date +%Y-%m-%d) - [Fix XSS vulnerability in talks iframe fallback URL]
+**Vulnerability:** XSS vulnerability in `TalkLayout.tsx` where a malformed `videoUrl` could be mapped directly to an `iframe` `src` attribute containing unsafe URI schemes like `javascript:`.
+**Learning:** `iframe` `src` attributes do not automatically sanitize unsafe protocols. If user input or MDX frontmatter overrides a URL without standardizing it, malicious payloads like `javascript:alert(1)` could execute scripts within the iframe's context.
+**Prevention:** Always validate external URL protocols when dynamically passing them to `iframe` `src` or `<Link>` parameters using the `new URL(url, 'http://localhost')` pattern and only allow `http:` or `https:`. Fallback to `about:blank` for safe defaults.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,14 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('sanitizes javascript: URIs to prevent XSS', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('sanitizes data: URIs to prevent XSS', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,24 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URLs and fall through to return about:blank
+  }
+
+  // Return safe default to prevent XSS via javascript: or data: URIs in iframes
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unsanitized URL protocol in `getYouTubeEmbedUrl` allows arbitrary execution of `javascript:` or `data:` URIs when mapped to an `iframe`'s `src` attribute.
🎯 **Impact:** An attacker could execute arbitrary JavaScript within the application's context if they control the `videoUrl` frontmatter value in an MDX file.
🔧 **Fix:** Introduced a `new URL()` check to strictly whitelist `http:` and `https:` protocols. If parsing fails or the protocol is malicious, the URL defaults safely to `about:blank`.
✅ **Verification:** Added dedicated Vitest tests covering `javascript:` and `data:` protocols, ensuring they resolve to `about:blank` without error.

---
*PR created automatically by Jules for task [16410928728400366858](https://jules.google.com/task/16410928728400366858) started by @jreed91*