### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe fallback url

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+## 2025-02-14 - [XSS via Fallback URL in Iframe]
+**Vulnerability:** XSS vulnerability in `getYouTubeEmbedUrl` where an unvalidated fallback `videoUrl` could be passed to an `iframe`'s `src` attribute. Malicious actors could provide `javascript:` or `data:` URIs.
+**Learning:** React and Next.js do not natively sanitize strings passed to `iframe` `src` attributes. Regex checks can be incomplete for fallback mechanisms.
+**Prevention:** Always validate protocols of external URLs using the native `URL` constructor (e.g., ensuring `http:` or `https:`) before injection to prevent XSS vulnerabilities from unsafe URIs. Use `about:blank` as a safe fallback for invalid or unsafe protocols.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,14 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('sanitizes javascript URIs to prevent XSS', () => {
+    const url = 'javascript:alert("XSS")';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('sanitizes data URIs to prevent XSS', () => {
+    const url = 'data:text/html,<script>alert("XSS")</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,23 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Security: Prevent XSS by validating the fallback protocol using the native URL constructor.
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URLs
+  }
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unvalidated fallback `videoUrl` passed into an `iframe`'s `src` attribute could allow XSS if an attacker supplied a malicious URI like `javascript:alert(1)`.
🎯 **Impact:** Potential remote code execution via XSS if an attacker could control or inject content into MDX files that generate the iframe source.
🔧 **Fix:** Added protocol validation using the native `URL` constructor to ensure the fallback URL starts with `http:` or `https:`. If the parsing fails or the protocol is dangerous, it safely falls back to `about:blank`. Added tests for `javascript:` and `data:` URIs.
✅ **Verification:** Run `npm run test` to verify the new tests in `app/db/talks.test.ts` pass, successfully converting unsafe URIs to `about:blank`.

---
*PR created automatically by Jules for task [5509405162507018356](https://jules.google.com/task/5509405162507018356) started by @jreed91*