### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS and enhance XSS in safeJsonStringify

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,13 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2026-07-10 - [Enhance XSS & DoS protection in safeJsonStringify]
+**Vulnerability:** DoS vulnerability via  when  returns , and missing defense-in-depth XSS escapes in .
+**Learning:**  returns `undefined` (not the string `"undefined"`) when passed `undefined`, functions, or symbols. Calling `.replace()` on this result causes a runtime crash. Furthermore, failing to escape `/`, `\u2028`, and `\u2029` can lead to subtle XSS or syntax errors when JSON is embedded in `<script>` blocks.
+**Prevention:** Always check if the result of  is  before chaining string methods, and proactively escape forward slashes and unicode line terminators when stringifying JSON for script tags.
+
+## 2025-03-03 - [Enhance XSS & DoS protection in safeJsonStringify]
+**Vulnerability:** DoS vulnerability via `TypeError` when `JSON.stringify` returns `undefined`, and missing defense-in-depth XSS escapes in `safeJsonStringify`.
+**Learning:** `JSON.stringify` returns `undefined` (not the string `"undefined"`) when passed `undefined`, functions, or symbols. Calling `.replace()` on this result causes a runtime crash. Furthermore, failing to escape `/`, `\u2028`, and `\u2029` can lead to subtle XSS or syntax errors when JSON is embedded in `<script>` blocks.
+**Prevention:** Always check if the result of `JSON.stringify` is `undefined` before chaining string methods, and proactively escape forward slashes and unicode line terminators when stringifying JSON for script tags.

--- a/app/utils/sanitize.ts
+++ b/app/utils/sanitize.ts
@@ -3,8 +3,15 @@
  * Replaces <, >, and & with their unicode escape sequences.
  */
 export function safeJsonStringify(data: unknown): string {
-  return JSON.stringify(data)
+  const json = JSON.stringify(data);
+  if (json === undefined) {
+    return 'null';
+  }
+  return json
     .replace(/</g, '\\u003c')
     .replace(/>/g, '\\u003e')
-    .replace(/&/g, '\\u0026');
+    .replace(/&/g, '\\u0026')
+    .replace(/\//g, '\\u002f')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
 }


### PR DESCRIPTION
🚨 Severity: HIGH/MEDIUM (DoS crash, Defense-in-Depth XSS)
💡 Vulnerability: `JSON.stringify(undefined)` returns `undefined`, which caused a `TypeError` DoS when `.replace()` was called on it. Also, missing escapes for forward slashes and line separators (`\u2028`, `\u2029`) could theoretically be abused in some script contexts.
🎯 Impact: Resolves a potential DoS vulnerability when malformed data is serialized, and significantly hardens XSS protection for inline `<script>` tags by comprehensively escaping critical characters.
🔧 Fix: Fallback to `"null"` if `JSON.stringify` returns `undefined`, and added additional `.replace()` checks for `/`, `\u2028`, and `\u2029`.
✅ Verification: Confirmed via isolated script tests and standard vitest runs.

---
*PR created automatically by Jules for task [14063731648306478932](https://jules.google.com/task/14063731648306478932) started by @jreed91*