### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix XSS via unsafe iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-02-27 - [Fix XSS vulnerability via unsafe iframe src]
+**Vulnerability:** XSS vulnerability where untrusted URLs from MDX metadata could be used in an iframe `src` attribute (e.g. `javascript:alert(1)`) leading to script execution within the context of the iframe.
+**Learning:** React and Next.js do not natively sanitize strings passed to `iframe` `src` attributes. Regular expressions for YouTube validation will safely block invalid URLs, but if they fall back to using the string directly, dangerous schemas like `javascript:` and `data:` can bypass the check and execute code.
+**Prevention:** Always validate protocols of external URLs using the native `URL` constructor (e.g., `new URL(url, 'http://localhost')`) to reliably check the `.protocol` property, ensuring it strictly matches `http:` or `https:`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,19 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for malicious javascript protocols', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for malicious data protocols', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('allows root-relative URLs', () => {
+    const url = '/relative/path/to/video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,17 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  if (!videoUrl) return videoUrl;
+
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URLs and fall back to blank
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: The `getYouTubeEmbedUrl` function in `app/db/talks.ts` falls back to returning the unvalidated `videoUrl` directly if it does not match a YouTube URL. When this value is used in an iframe `src` attribute (as in `app/components/TalkLayout.tsx`), it allows malicious protocols like `javascript:` or `data:`, leading to Cross-Site Scripting (XSS).
🎯 **Impact**: If a malicious string (e.g. `javascript:alert(1)`) is parsed from MDX metadata, it will be executed within the context of the iframe, bypassing standard validation.
🔧 **Fix**: Implemented strict protocol validation using the WHATWG `URL` constructor. The `getYouTubeEmbedUrl` function now safely validates non-YouTube URLs, allowing only `http:` and `https:` protocols (including root-relative paths handled correctly by the `URL` constructor's base parameter) and returns `'about:blank'` for any unsafe or invalid protocols.
✅ **Verification**: Run `npm run test -- --run` to verify new and existing tests pass. Run `npm run build` to ensure static pages build successfully without issues.

---
*PR created automatically by Jules for task [17185133368822082414](https://jules.google.com/task/17185133368822082414) started by @jreed91*