### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe XSS via SSRF in Talks]
+**Vulnerability:** XSS vulnerability where untrusted URLs provided in MDX frontmatter (`videoUrl`) were placed into an `iframe`'s `src` attribute without sanitization. An attacker could provide a malicious `javascript:` or `data:` URI which would be executed when the iframe loads.
+**Learning:** React and Next.js do not natively sanitize strings passed to `iframe` `src` attributes. A regex check for youtube urls was present but allowed any other url to be returned unchanged, leading to the vulnerability.
+**Prevention:** Always validate protocols (e.g., ensuring `http:` or `https:`) of external URLs using the native `URL` constructor before injection to prevent XSS vulnerabilities from `javascript:` or `data:` URIs. Empty URLs or relative paths can be supported but must be evaluated properly.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -39,6 +39,26 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl('')).toBe('');
   });
 
+  it('returns about:blank for javascript URIs', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for padded javascript URIs', () => {
+    const url = '   javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for data URIs', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns the original URL for local paths', () => {
+    const url = '/local-video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
+
   it('handles video IDs with hyphens and underscores', () => {
     const url = 'https://youtu.be/abc-def_123';
     expect(getYouTubeEmbedUrl(url)).toBe(

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,17 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  if (!videoUrl) return videoUrl;
+
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URLs
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe src

- 🚨 Severity: HIGH
- 💡 Vulnerability: `getYouTubeEmbedUrl` allowed untrusted `javascript:` and `data:` URIs to be injected into an iframe's `src` attribute.
- 🎯 Impact: If malicious content entered the `videoUrl` frontmatter field, it would trigger Cross-Site Scripting (XSS) when the iframe loaded.
- 🔧 Fix: Implemented native `URL` constructor validation to ensure protocols are only `http:` or `https:`. Invalid or unsafe URLs fallback to `about:blank`.
- ✅ Verification: Added specific Vitest test cases to cover standard URLs, empty strings, local paths, and malicious payloads.

---
*PR created automatically by Jules for task [10283607768045723541](https://jules.google.com/task/10283607768045723541) started by @jreed91*