### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix XSS via Unsafe iframe src]
+**Vulnerability:** XSS vulnerability where user-provided `videoUrl` in MDX frontmatter was rendered directly into the `src` attribute of an `iframe` in `TalkLayout.tsx` without protocol validation if it didn't match the YouTube regex.
+**Learning:** `iframe` `src` attributes can execute Javascript if prefixed with `javascript:` or `data:`. React does not natively sanitize URLs passed to iframe src.
+**Prevention:** Always validate protocols of external URLs using the native `URL` constructor before injecting them into `iframe` `src` attributes or `Link` hrefs. Fall back to safe alternatives like `about:blank` for invalid protocols.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,19 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for javascript: URLs', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for data: URLs', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns the original URL for root-relative paths', () => {
+    const url = '/videos/my-talk.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,24 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Sentinel: XSS Prevention
+  // Ensure the fallback URL has a safe protocol to prevent javascript: or data: URIs
+  // from executing in the iframe src attribute.
+  try {
+    const url = new URL(videoUrl, 'http://localhost');
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // URL parsing failed
+  }
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: User-provided `videoUrl` in MDX frontmatter was rendered directly into the `src` attribute of an `iframe` in `TalkLayout.tsx` without protocol validation if it didn't match the YouTube regex. This allowed execution of Javascript via `javascript:` or `data:` URIs.
🎯 Impact: An attacker could execute arbitrary Javascript in the context of the user's session if they can control the `videoUrl` field in the MDX frontmatter.
🔧 Fix: Validated the protocol of the provided URL using the native `URL` constructor before returning it from `getYouTubeEmbedUrl`. Defaults to `about:blank` for unsafe protocols like `javascript:` or `data:`.
✅ Verification: Ran unit tests covering `javascript:`, `data:`, and root-relative paths.

---
*PR created automatically by Jules for task [2989922745505631399](https://jules.google.com/task/2989922745505631399) started by @jreed91*