### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-02-28 - XSS vulnerability in iframe src
+**Vulnerability:** XSS vulnerability where user-provided `videoUrl` variables embedded in dynamic `iframe` `src` attributes allowed execution of `javascript:` or `data:` URIs.
+**Learning:** Next.js and React do not natively sanitize strings passed to `iframe` `src` attributes. A malicious user or frontmatter author could embed arbitrary javascript URIs into `videoUrl` and bypass typical XSS protections since `iframe` allows executing embedded protocols.
+**Prevention:** Always validate protocols (e.g., ensuring `http:` or `https:`) of external URLs using the native `URL` constructor before injection to prevent XSS vulnerabilities from `javascript:` or `data:` URIs.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,12 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('sanitizes javascript: URIs to about:blank', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('sanitizes data: URIs to about:blank', () => {
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,15 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
+
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return 'about:blank';
+    }
+  } catch (e) {
+    return 'about:blank';
+  }
+
   return videoUrl;
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** XSS vulnerability where user-provided `videoUrl` variables in dynamic `iframe` `src` attributes allowed execution of `javascript:` or `data:` URIs without explicit protocol validation.
🎯 **Impact:** An attacker could execute arbitrary javascript context by passing a `javascript:` URI as a `videoUrl` since `iframe` permits embedded protocol execution, leading to potential Cross-Site Scripting (XSS).
🔧 **Fix:** Added validation for `videoUrl` inside `getYouTubeEmbedUrl` using the native `URL` constructor to enforce `http:` or `https:` protocols, mapping any malicious URIs to `about:blank`. Added tests for `javascript:` and `data:` protocols.
✅ **Verification:** Verified via test suite (`npm run test -- --run`). Added tests ensure that `javascript:alert(1)` and `data:text/html,...` are correctly mapped to `about:blank`. Recorded critical findings in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [5213317467186538775](https://jules.google.com/task/5213317467186538775) started by @jreed91*