### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF/XSS via Unsanitized iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2024-05-24 - SSRF/XSS via Unsanitized iframe src
+**Vulnerability:** `getYouTubeEmbedUrl` in `app/db/talks.ts` returned unvalidated strings for non-YouTube URLs. This was passed directly into an `iframe` `src` attribute in `app/components/TalkLayout.tsx`, allowing attackers to supply `javascript:` or `data:` URIs and execute arbitrary scripts or load malicious content if `talk.metadata.videoUrl` is controlled by them.
+**Learning:** React does not inherently validate URL protocols passed to `iframe` `src` (or similar attributes like `href`), meaning `javascript:` URIs can be used for XSS.
+**Prevention:** Always validate and enforce safe protocols (`http:`, `https:`) or allow controlled local paths for user-provided URLs that are dynamically injected into `src` or `href` attributes. Fallback to `about:blank` for invalid inputs. Use the native `URL` constructor to reliably parse protocols.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,18 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for dangerous javascript: URIs', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('returns about:blank for dangerous data: URIs', () => {
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe(
+      'about:blank'
+    );
+  });
+
+  it('allows root-relative local paths', () => {
+    expect(getYouTubeEmbedUrl('/local-video.mp4')).toBe('/local-video.mp4');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,17 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  if (!videoUrl) return '';
+
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore error and fallthrough to about:blank
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
This PR patches a critical XSS/SSRF vulnerability within the `getYouTubeEmbedUrl` function (`app/db/talks.ts`) where unvalidated non-YouTube URLs were returned as-is and injected directly into an `iframe`'s `src` attribute. By enforcing `http:` or `https:` protocols (or allowing relative local paths), we prevent attackers from utilizing `javascript:` or `data:` URIs to execute arbitrary scripts if they control the `videoUrl` metadata. Unit tests were added to ensure the safety constraints hold.

🚨 Severity: CRITICAL
💡 Vulnerability: SSRF/XSS via unsanitized iframe `src` passing `javascript:` or `data:` payloads
🎯 Impact: Arbitrary script execution or malicious iframe rendering if `videoUrl` metadata is controlled
🔧 Fix: Used native `URL` constructor to assert `http:` or `https:` protocol and fallback to `about:blank`.
✅ Verification: Tested against standard YouTube links, absolute links, and malicious URIs via vitest.

---
*PR created automatically by Jules for task [15974390076165135348](https://jules.google.com/task/15974390076165135348) started by @jreed91*