### PR TITLE
🛡️ Sentinel: [HIGH] Fix Stored XSS via MDX Slug Interpolation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Stored XSS via MDX Slug Interpolation]
+**Vulnerability:** Slugs extracted from MDX files were directly interpolated into URL paths (e.g., `<Link href={'/blog/' + slug}>` or `editUrl`) without sanitization in `TalkCard.tsx`, `BlogPostCard.tsx`, `BlogPost.tsx`, and `BlogLayout.tsx`. If a maliciously crafted slug containing unexpected characters or path traversal sequences were to be processed, it could lead to Stored XSS or broken links.
+**Learning:** File-derived variables, even those assumed to be safe like filenames or slugs, must be treated as untrusted user input when injected into URLs, attributes, or HTML contexts. CodeQL checks flag these direct interpolations as potential XSS vulnerabilities.
+**Prevention:** Always sanitize dynamic URL segments using `encodeURIComponent()` (e.g., `/blog/${encodeURIComponent(slug)}`) to ensure any special characters are safely URL-encoded before being rendered into `href` attributes.

--- a/app/components/BlogLayout.tsx
+++ b/app/components/BlogLayout.tsx
@@ -7,7 +7,7 @@ import { CustomMDX } from "./Mdx";
 import TableOfContents from "./TableOfContents";
 
 const editUrl = (slug: string) =>
-  `https://github.com/jreed91/jacobreed.dev/edit/master/data/blog/${slug}.mdx`;
+  `https://github.com/jreed91/jacobreed.dev/edit/master/data/blog/${encodeURIComponent(slug)}.mdx`;
 const discussUrl = (slug: string) =>
   `https://mobile.twitter.com/search?q=${encodeURIComponent(
     `https://jacobreed.dev/blog/${slug}`

--- a/app/components/BlogPost.tsx
+++ b/app/components/BlogPost.tsx
@@ -5,7 +5,7 @@ import { parseISO, format } from 'date-fns';
 
 export default function BlogPost ({ blog }: { blog: Blog}) {
   return (
-    <Link href={`/blog/${blog.slug}`} className="w-full ">
+    <Link href={`/blog/${encodeURIComponent(blog.slug)}`} className="w-full ">
         <div className="w-full mb-8 transform hover:scale-[1.01] transition-all">
           <div className="flex flex-col justify-between md:flex-row">
             <h4 className="w-full mb-2 text-lg font-medium text-gray-900 md:text-xl dark:text-gray-100">

--- a/app/components/BlogPostCard.tsx
+++ b/app/components/BlogPostCard.tsx
@@ -5,7 +5,7 @@ import { parseISO, format } from 'date-fns';
 export default function BlogPostCard({ title, slug, summary, date, readingTime }: {title: string, slug: string, summary: string, date: string, readingTime: string}) {
 
   return (
-    <Link href={`/blog/${slug}`}  className={cn(
+    <Link href={`/blog/${encodeURIComponent(slug)}`}  className={cn(
       'transform hover:scale-[1.01] transition-all',
       'rounded-xl w-full md:w-1/3 bg-gradient-to-r p-1',
       'bg-gray-200'

--- a/app/components/TalkCard.tsx
+++ b/app/components/TalkCard.tsx
@@ -4,7 +4,7 @@ import { parseISO, format } from 'date-fns';
 
 export default function TalkCard({ talk }: { talk: Talk }) {
   return (
-    <Link href={`/talks/${talk.slug}`} className="w-full">
+    <Link href={`/talks/${encodeURIComponent(talk.slug)}`} className="w-full">
       <div className="w-full mb-8 transform hover:scale-[1.01] transition-all">
         <div className="flex flex-col justify-between md:flex-row">
           <h4 className="w-full mb-2 text-lg font-medium text-gray-900 md:text-xl dark:text-gray-100">


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unsanitized file-derived slugs (from MDX filenames) were being directly interpolated into `href` attributes in several components (`TalkCard`, `BlogPostCard`, `BlogPost`, `BlogLayout`). This could allow Stored XSS if a maliciously crafted slug containing unexpected characters or path traversal sequences were to be processed.
🎯 **Impact:** An attacker could potentially inject malicious scripts or manipulate URL structures, leading to unauthorized actions or data exposure if a user interacts with the compromised link.
🔧 **Fix:** Applied `encodeURIComponent` to the `slug` variable in all identified `href` interpolations, ensuring any special characters are safely URL-encoded before being rendered into the DOM. This also resolves potential CodeQL alerts for Stored XSS.
✅ **Verification:** Ran the test suite (`npm run test -- --run`) and verified that existing tests pass, confirming no functional regressions for standard slugs. Run `npm run build` to verify successful compilation.

---
*PR created automatically by Jules for task [6563772863930883832](https://jules.google.com/task/6563772863930883832) started by @jreed91*