### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in YouTube embed URL generation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-02-27 - [Sentinel: Prevent XSS in YouTube embed URL generation]
+**Vulnerability:** XSS vulnerability where untrusted user input from MDX frontmatter (`videoUrl`) was used as the fallback `src` for the `iframe` in `app/components/TalkLayout.tsx` without proper sanitization. The previous fallback just returned the `videoUrl` directly, which could contain `javascript:` or `data:` URIs.
+**Learning:** `iframe` `src` attributes are not natively sanitized by React/Next.js. Always validate protocols (e.g., ensuring `http:` or `https:`) of external URLs using the native `URL` constructor before injection to prevent XSS vulnerabilities from `javascript:` or `data:` URIs.
+**Prevention:** Use the `new URL(url, base)` constructor to parse and check `.protocol === 'http:' || .protocol === 'https:'`. Relative URLs can be parsed safely by providing a base URL like `'http://localhost'`. Return a safe fallback like `about:blank` on error or invalid protocols.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,16 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for javascript: URIs', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('returns about:blank for data: URIs', () => {
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
+  });
+
+  it('allows relative path URLs (treated as http/https via base)', () => {
+    expect(getYouTubeEmbedUrl('/videos/local.mp4')).toBe('/videos/local.mp4');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,15 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const parsedUrl = new URL(videoUrl, 'http://localhost');
+    if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Parsing error
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: XSS vulnerability where untrusted user input from MDX frontmatter (`videoUrl`) was used as the fallback `src` for the `iframe` in `app/components/TalkLayout.tsx` without proper sanitization. The previous fallback just returned the `videoUrl` directly, which could contain `javascript:` or `data:` URIs.
🎯 **Impact**: An attacker could inject a malicious `videoUrl` like `javascript:alert(1)` into a talk's MDX frontmatter, which would execute arbitrary JavaScript in the context of the user's browser when they visit the talk page.
🔧 **Fix**: Updated `getYouTubeEmbedUrl` to validate the protocol of the fallback URL using `new URL(...)`. If the URL doesn't use `http:` or `https:`, it returns `about:blank`.
✅ **Verification**: Run `npm run test` to verify the new tests pass, ensuring `javascript:` and `data:` URIs result in `about:blank`.

---
*PR created automatically by Jules for task [10141878147240043528](https://jules.google.com/task/10141878147240043528) started by @jreed91*