### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS in getYouTubeEmbedUrl

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+## 2024-05-18 - XSS Vulnerability in YouTube Embed URLs
+**Vulnerability:** XSS vulnerability in `getYouTubeEmbedUrl` when falling back to external `videoUrl` directly without validating that it is a safe protocol (e.g. it allows `javascript:` or `data:` URIs, leading to XSS inside the `iframe` `src`).
+**Learning:** `iframe` `src` injection is a significant vector for XSS if unvalidated input is passed to it; simple string fallback exposes the app to protocol-based attacks.
+**Prevention:** Use the native `URL` constructor to reliably extract and check the `.protocol` property, ensuring it's either `http:` or `https:`. Return `about:blank` for unexpected protocols.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,14 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('safely rejects javascript: URIs', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('safely rejects data: URIs', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,23 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
+
+  try {
+    const url = new URL(videoUrl, 'http://localhost');
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return 'about:blank';
+    }
+  } catch {
+    return 'about:blank';
+  }
+
   return videoUrl;
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `getYouTubeEmbedUrl` function directly falls back to an external `videoUrl` when a YouTube pattern is not met. Without checking the protocol, this allows malicious users (e.g. through CMS input if `videoUrl` comes from unvalidated frontmatter) to pass in `javascript:` or `data:` URIs.
🎯 **Impact:** When rendered in the `TalkLayout` component via the `iframe` `src`, arbitrary JavaScript could be executed on the user's browser, leading to XSS.
🔧 **Fix:** Utilized the native `URL` constructor to validate the provided URL. Now, if the protocol is not explicitly `http:` or `https:`, the function safely rejects it and returns `about:blank`.
✅ **Verification:** Added `javascript:` and `data:` URI tests to `app/db/talks.test.ts`. Verified they return `about:blank` and ensured the test suite fully passes.

---
*PR created automatically by Jules for task [1643360631280392060](https://jules.google.com/task/1643360631280392060) started by @jreed91*