### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in video embed URLs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2024-05-18 - [Fix XSS in getYouTubeEmbedUrl]
+**Vulnerability:** Unvalidated protocols in Markdown frontmatter `videoUrl` allowed `javascript:` and `data:` URIs to be injected into `<iframe src={...}>`.
+**Learning:** `iframe` `src` attributes are naturally vulnerable to XSS if the URL protocol is unvalidated. Next.js does not sanitize string input into `iframe` properties automatically.
+**Prevention:** Always validate URL protocols using the native `URL` constructor (e.g. `new URL(url, 'http://localhost')`) before injecting user-provided links into DOM attributes. Ensure it matches `http:` or `https:`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,9 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('mitigates XSS by returning about:blank for javascript: URLs', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,19 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // XSS protection: Validate URL protocol
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      // If it's a relative url mapped to http://localhost, check if the original videoUrl was empty
+      if (videoUrl === '') {
+        return '';
+      }
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URLs
+  }
+  return 'about:blank';
 }


### PR DESCRIPTION
* 🚨 **Severity:** HIGH
* 💡 **Vulnerability:** The `getYouTubeEmbedUrl` function in `app/db/talks.ts` does not validate the protocol of fallback URLs, allowing malicious actors to inject `javascript:` or `data:` URIs via Markdown frontmatter, which are then rendered into the `src` attribute of an `iframe`.
* 🎯 **Impact:** Exploitation could allow arbitrary JavaScript execution in the context of the user's session (Cross-Site Scripting / XSS).
* 🔧 **Fix:** Added protocol validation using the native `URL` constructor. Non-YouTube URLs are now verified to only use `http:` or `https:` protocols. All other schemes default to `about:blank`.
* ✅ **Verification:** A new unit test was added to explicitly check mitigation against `javascript:alert(1)`. Run `npx vitest --run app/db/talks.test.ts` to verify the tests pass.

---
*PR created automatically by Jules for task [17665986942169912267](https://jules.google.com/task/17665986942169912267) started by @jreed91*