### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS in iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+## 2025-03-03 - [Fix iframe src XSS]
+**Vulnerability:** XSS vulnerability where user-provided or markdown-sourced `videoUrl` could be rendered directly into `iframe` `src` attributes without protocol validation.
+**Learning:** `iframe` `src` attributes do not sanitize content natively and can execute `javascript:` and `data:` URIs, leading to XSS vulnerabilities if an attacker provides a malicious URL.
+**Prevention:** Always parse untrusted URLs intended for `iframe` `src` (or external links) using `new URL(url, base)` and validate that the `protocol` is restricted to safe schemes like `http:` and `https:`. Return `about:blank` for invalid protocols.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -39,6 +39,16 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl('')).toBe('');
   });
 
+  it('rejects javascript: URIs to prevent XSS', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('rejects data: URIs to prevent XSS', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
   it('handles video IDs with hyphens and underscores', () => {
     const url = 'https://youtu.be/abc-def_123';
     expect(getYouTubeEmbedUrl(url)).toBe(

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,15 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
+
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return 'about:blank';
+    }
+  } catch (e) {
+    return 'about:blank';
+  }
+
   return videoUrl;
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH

💡 **Vulnerability:** Cross-Site Scripting (XSS). The `videoUrl` property (sourced from Markdown files or user input) was rendered directly into the `src` attribute of an `iframe` in `app/components/TalkLayout.tsx` without validating its protocol. Since `iframe` `src` attributes do not sanitize content natively, an attacker could provide a malicious URI like `javascript:alert(1)` or `data:text/html,<script>alert(1)</script>`.

🎯 **Impact:** If exploited, an attacker could execute arbitrary JavaScript within the context of the application, potentially leading to session hijacking, data theft, or defacement.

🔧 **Fix:** Updated the `getYouTubeEmbedUrl` function in `app/db/talks.ts` to parse the incoming URL using the native `URL` constructor (with a safe fallback base). It now strictly enforces that the URL's `.protocol` is either `http:` or `https:`. For all other protocols, it returns `about:blank`, neutralizing the threat.

✅ **Verification:** Verified by running the test suite (`npm run test -- --run`). New test cases in `app/db/talks.test.ts` confirm that `javascript:` and `data:` URIs are correctly rejected and fall back to `about:blank`, while standard URLs and empty strings remain supported.

---
*PR created automatically by Jules for task [4042797348955743273](https://jules.google.com/task/4042797348955743273) started by @jreed91*