### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2024-07-26 - [XSS via iframe src]
+**Vulnerability:** The application was not validating the protocol of non-YouTube video URLs injected into the `iframe` `src` attribute within `app/components/TalkLayout.tsx`, allowing for arbitrary XSS via `javascript:` or `data:` URIs parsed from markdown frontmatter.
+**Learning:** React and Next.js do not natively sanitize strings passed to `iframe` `src` attributes. Regex checks or naive `startsWith` string checks for URLs can easily be bypassed by whitespace padding.
+**Prevention:** Always validate the protocol of external URLs dynamically injected into `iframe` or `href` attributes using the native `URL` constructor (e.g., `new URL(url, 'http://localhost')`) to reliably check the `.protocol` property, defaulting to a safe protocol or `about:blank` for invalid inputs.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,12 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('neutralizes unsafe javascript: URIs', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('neutralizes unsafe data: URIs', () => {
+    expect(getYouTubeEmbedUrl('data:text/html,<h1>XSS</h1>')).toBe('about:blank');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,13 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return videoUrl;
+    }
+    return 'about:blank';
+  } catch (e) {
+    return 'about:blank';
+  }
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `iframe` `src` attribute inside `app/components/TalkLayout.tsx` was vulnerable to XSS if a `javascript:` or `data:` URI was passed via markdown frontmatter. The `getYouTubeEmbedUrl` function did not validate or sanitize non-YouTube URLs.
🎯 **Impact:** An attacker could execute arbitrary JavaScript within the context of the user's browser by controlling the markdown frontmatter `videoUrl` for a talk.
🔧 **Fix:** Utilized the native `URL` constructor inside `getYouTubeEmbedUrl` to validate that fallback URLs start with `http:` or `https:`. Unsafe URIs default to `about:blank`.
✅ **Verification:** Added test cases in `app/db/talks.test.ts` to ensure unsafe URIs are neutralized. Ran `npm run test -- --run` to verify all 44 tests pass successfully.

---
*PR created automatically by Jules for task [3394870059198385268](https://jules.google.com/task/3394870059198385268) started by @jreed91*