### PR TITLE
🛡️ Sentinel: [HIGH] Sanitize iframe src in TalkLayout to prevent XSS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2024-05-30 - XSS Vulnerability in TalkLayout
+**Vulnerability:** Unsanitized dynamic `iframe` `src` attribute from markdown files allowed injection of `javascript:` URIs, leading to Cross-Site Scripting (XSS).
+**Learning:** `iframe` `src` attributes do not inherently block `javascript:` or `data:` URIs in React/Next.js.
+**Prevention:** Always validate protocols of user-provided or statically generated URLs destined for interactive elements (`a` tags, `iframe` `src`) using `new URL()` to enforce only `http:` or `https:`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,17 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('sanitizes javascript URLs to about:blank', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('  javascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('sanitizes data URLs to about:blank', () => {
+    expect(getYouTubeEmbedUrl('data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==')).toBe('about:blank');
+  });
+
+  it('allows relative path URLs', () => {
+    expect(getYouTubeEmbedUrl('/my-video.mp4')).toBe('/my-video.mp4');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,13 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // URL parsing failed
+  }
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: Unsanitized dynamic `iframe` `src` attribute originating from markdown file metadata (`videoUrl`) allowed for the potential injection of `javascript:` or `data:` URIs, leading to Cross-Site Scripting (XSS).
🎯 **Impact**: If a malicious user or compromised source modified the markdown files, arbitrary script execution could occur within the context of the user's browser via `javascript:` URIs.
🔧 **Fix**: Implemented strict URL protocol validation using the native `URL` constructor inside `getYouTubeEmbedUrl`. If the URL doesn't match a valid YouTube URL, it is parsed and verified to ensure it uses the `http:` or `https:` protocol (or is a valid relative path resolving to `http:`). Unsafe protocols fallback securely to `about:blank`.
✅ **Verification**: Run `npm run test -- --run` to execute the Vitest suite, which now includes tests confirming `javascript:`, `data:`, and empty URLs are handled correctly and safely.

---
*PR created automatically by Jules for task [10320895670977117549](https://jules.google.com/task/10320895670977117549) started by @jreed91*