### PR TITLE
🛡️ Sentinel: [HIGH] Sanitize user input to prevent XSS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+## 2025-02-14 - Prevent XSS in YouTube Embeds
+**Vulnerability:** XSS vulnerability in Talk layout via `getYouTubeEmbedUrl`. The function fell back to returning the unsanitized `videoUrl` directly for non-YouTube strings. If a malicious user controlled the markdown frontmatter, they could inject `javascript:` or `data:` URLs into the `src` attribute of the `iframe` in `TalkLayout.tsx`.
+**Learning:** Returning strings directly for external links or `iframe` sources without validating the protocol is dangerous. Even with a regex that matches valid domains (like YouTube), the fallback path must also be sanitized.
+**Prevention:** Always validate protocols of fallback URLs for `iframe` `src` attributes or dynamic links using `new URL()` to enforce safe schemes like `http:` or `https:`. Reject or neutralize other protocols (like `javascript:`).

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,19 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('sanitizes javascript: URLs to about:blank', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('sanitizes data: URLs to about:blank', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('allows safe relative URLs', () => {
+    const url = '/local-video.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,22 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  // Security: Prevent XSS by validating the protocol for fallback URLs
+  try {
+    const parsedUrl = new URL(videoUrl, 'http://localhost');
+    if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URLs
+  }
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** XSS vulnerability in `getYouTubeEmbedUrl` in `app/db/talks.ts`. If a non-YouTube URL is provided, it returns the unvalidated string directly, which is then used in an `iframe`'s `src` attribute. This allows `javascript:` or `data:` URIs to be injected via markdown frontmatter.
🎯 **Impact:** If exploited, an attacker could execute arbitrary JavaScript within the context of the user's browser viewing the talk.
🔧 **Fix:** Added protocol validation using `new URL()`. It now strictly requires `http:` or `https:` protocols (allowing safe relative URLs resolved against `http://localhost`) and defaults to `about:blank` for everything else, completely neutralizing malicious schemes.
✅ **Verification:** Unit tests added for `javascript:`, `data:`, and valid relative paths. Run tests with `npm run test -- --run`.

---
*PR created automatically by Jules for task [15864056595477534748](https://jules.google.com/task/15864056595477534748) started by @jreed91*