### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in YouTube embeds

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe XSS in YouTube embeds]
+**Vulnerability:** XSS vulnerability in `getYouTubeEmbedUrl` where fallback URLs were returned raw without protocol validation. If a malicious user controlled the metadata `videoUrl` and supplied a `javascript:` or `data:` URI, it could be executed when embedded into an `iframe` `src` attribute.
+**Learning:** React and Next.js do not natively sanitize strings passed to `iframe` `src` attributes. Regex or `startsWith` checks can often be bypassed. The native `URL` constructor is the most reliable way to extract and validate protocols safely.
+**Prevention:** Always validate protocols (e.g., ensuring `http:` or `https:`) of external URLs using the native `URL` constructor (with a dummy base URL for relative paths) before injection to prevent XSS vulnerabilities from `javascript:` or `data:` URIs.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,14 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('sanitizes javascript: URIs to about:blank', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('sanitizes data: URIs to about:blank', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,23 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const parsedUrl = new URL(videoUrl, 'http://localhost');
+    if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URLs
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: XSS vulnerability in `getYouTubeEmbedUrl` via `iframe` `src` injection of `javascript:` or `data:` URIs.
🎯 Impact: An attacker could execute arbitrary JavaScript within the iframe context if malicious URLs get injected via metadata.
🔧 Fix: Validated the protocol of the fallback `videoUrl` using the native `URL` constructor to only allow `http:` or `https:` protocols, and gracefully failing to `about:blank`.
✅ Verification: Run `npm run test -- --run` to ensure all tests, including new test cases for `javascript:` URIs pass.

---
*PR created automatically by Jules for task [11265442893616862366](https://jules.google.com/task/11265442893616862366) started by @jreed91*