### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe src

### DIFF
--- a/app/components/TalkCard.tsx
+++ b/app/components/TalkCard.tsx
@@ -4,7 +4,7 @@ import { parseISO, format } from 'date-fns';
 
 export default function TalkCard({ talk }: { talk: Talk }) {
   return (
-    <Link href={`/talks/${talk.slug}`} className="w-full">
+    <Link href={`/talks/${encodeURIComponent(talk.slug)}`} className="w-full">
       <div className="w-full mb-8 transform hover:scale-[1.01] transition-all">
         <div className="flex flex-col justify-between md:flex-row">
           <h4 className="w-full mb-2 text-lg font-medium text-gray-900 md:text-xl dark:text-gray-100">

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -1,48 +1,63 @@
-import { describe, it, expect } from 'vitest';
-import { getYouTubeEmbedUrl } from './talks';
+import { describe, it, expect } from "vitest";
+import { getYouTubeEmbedUrl } from "./talks";
 
-describe('getYouTubeEmbedUrl', () => {
-  it('converts a standard youtube.com watch URL', () => {
-    const url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+describe("getYouTubeEmbedUrl", () => {
+  it("converts a standard youtube.com watch URL", () => {
+    const url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/dQw4w9WgXcQ'
+      "https://www.youtube.com/embed/dQw4w9WgXcQ",
     );
   });
 
-  it('converts a youtu.be short URL', () => {
-    const url = 'https://youtu.be/dQw4w9WgXcQ';
+  it("converts a youtu.be short URL", () => {
+    const url = "https://youtu.be/dQw4w9WgXcQ";
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/dQw4w9WgXcQ'
+      "https://www.youtube.com/embed/dQw4w9WgXcQ",
     );
   });
 
-  it('converts a youtube.com/embed URL', () => {
-    const url = 'https://www.youtube.com/embed/dQw4w9WgXcQ';
+  it("converts a youtube.com/embed URL", () => {
+    const url = "https://www.youtube.com/embed/dQw4w9WgXcQ";
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/dQw4w9WgXcQ'
+      "https://www.youtube.com/embed/dQw4w9WgXcQ",
     );
   });
 
-  it('converts a youtube.com/v/ URL', () => {
-    const url = 'https://www.youtube.com/v/dQw4w9WgXcQ';
+  it("converts a youtube.com/v/ URL", () => {
+    const url = "https://www.youtube.com/v/dQw4w9WgXcQ";
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/dQw4w9WgXcQ'
+      "https://www.youtube.com/embed/dQw4w9WgXcQ",
     );
   });
 
-  it('returns the original URL unchanged for non-YouTube URLs', () => {
-    const url = 'https://vimeo.com/123456789';
+  it("returns the original URL unchanged for non-YouTube URLs", () => {
+    const url = "https://vimeo.com/123456789";
     expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 
-  it('returns the original URL unchanged for empty string', () => {
-    expect(getYouTubeEmbedUrl('')).toBe('');
+  it("returns the original URL unchanged for empty string", () => {
+    expect(getYouTubeEmbedUrl("")).toBe("");
   });
 
-  it('handles video IDs with hyphens and underscores', () => {
-    const url = 'https://youtu.be/abc-def_123';
+  it("handles video IDs with hyphens and underscores", () => {
+    const url = "https://youtu.be/abc-def_123";
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/abc-def_123'
+      "https://www.youtube.com/embed/abc-def_123",
     );
+  });
+
+  it("blocks unsafe protocols like javascript:", () => {
+    const url = "javascript:alert(1)";
+    expect(getYouTubeEmbedUrl(url)).toBe("about:blank");
+  });
+
+  it("blocks unsafe protocols with padding", () => {
+    const url = "   javascript:alert(1)";
+    expect(getYouTubeEmbedUrl(url)).toBe("about:blank");
+  });
+
+  it("allows root-relative paths", () => {
+    const url = "/local-video.mp4";
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from "fs";
+import path from "path";
 
 type TalkMetadata = {
   title: string;
@@ -20,14 +20,14 @@ function parseFrontmatter(fileContent: string) {
   let frontmatterRegex = /---\s*([\s\S]*?)\s*---/;
   let match = frontmatterRegex.exec(fileContent);
   let frontMatterBlock = match![1];
-  let content = fileContent.replace(frontmatterRegex, '').trim();
-  let frontMatterLines = frontMatterBlock.trim().split('\n');
+  let content = fileContent.replace(frontmatterRegex, "").trim();
+  let frontMatterLines = frontMatterBlock.trim().split("\n");
   let metadata: Partial<TalkMetadata> = {};
 
   frontMatterLines.forEach((line) => {
-    let [key, ...valueArr] = line.split(': ');
-    let value = valueArr.join(': ').trim();
-    value = value.replace(/^['"](.*)['"]$/, '$1'); // Remove quotes
+    let [key, ...valueArr] = line.split(": ");
+    let value = valueArr.join(": ").trim();
+    value = value.replace(/^['"](.*)['"]$/, "$1"); // Remove quotes
     metadata[key.trim() as keyof TalkMetadata] = value;
   });
 
@@ -35,11 +35,11 @@ function parseFrontmatter(fileContent: string) {
 }
 
 function getMDXFiles(dir: fs.PathLike) {
-  return fs.readdirSync(dir).filter((file) => path.extname(file) === '.mdx');
+  return fs.readdirSync(dir).filter((file) => path.extname(file) === ".mdx");
 }
 
 function readMDXFile(filePath: fs.PathOrFileDescriptor) {
-  let rawContent = fs.readFileSync(filePath, 'utf-8');
+  let rawContent = fs.readFileSync(filePath, "utf-8");
   return parseFrontmatter(rawContent);
 }
 
@@ -58,7 +58,7 @@ function getMDXData(dir: string): Talk[] {
 }
 
 export function getTalks(): Talk[] {
-  return getMDXData(path.join(process.cwd(), 'content', 'talks'));
+  return getMDXData(path.join(process.cwd(), "content", "talks"));
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
@@ -68,5 +68,17 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  if (!videoUrl) return "";
+
+  // Prevent XSS by validating the protocol
+  try {
+    const parsedUrl = new URL(videoUrl, "http://localhost");
+    if (parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:") {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URLs
+  }
+  return "about:blank";
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `videoUrl` in MDX metadata was rendered in an iframe `src` without validation, allowing XSS via `javascript:` or `data:` URIs.
🎯 Impact: Attackers could execute arbitrary JavaScript in the user's browser if malicious content is loaded.
🔧 Fix: Validated the `videoUrl` protocol using the native `URL` constructor, allowing only `http:` and `https:`, falling back to `about:blank`.
✅ Verification: Run `npx vitest run app/db/talks.test.ts` to check the updated vitest tests.

---
*PR created automatically by Jules for task [5890925358807566700](https://jules.google.com/task/5890925358807566700) started by @jreed91*