### PR TITLE
🛡️ Sentinel: [HIGH] Fix iframe XSS vulnerability in getYouTubeEmbedUrl

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+## 2024-08-04 - XSS via Unvalidated Iframe SRC in MDX Metadata
+**Vulnerability:** The `getYouTubeEmbedUrl` function returned unvalidated `videoUrl` directly into an iframe `src` attribute when the URL didn't match the YouTube regex, allowing potential XSS via `javascript:` or `data:` URIs provided in MDX frontmatter.
+**Learning:** React and Next.js do not natively sanitize strings passed to iframe `src` attributes. External inputs, even from markdown metadata, must be treated as untrusted and strictly validated.
+**Prevention:** Always validate protocols (e.g., ensuring `http:` or `https:`) of external URLs using the native `URL` constructor before injection to prevent XSS vulnerabilities from `javascript:` or `data:` URIs.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,17 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('blocks javascript: URIs to prevent XSS', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('   javascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('blocks data: URIs to prevent XSS', () => {
+    expect(getYouTubeEmbedUrl('data:text/html,<html>')).toBe('about:blank');
+  });
+
+  it('allows relative paths (resolves to http: protocol with localhost base)', () => {
+    expect(getYouTubeEmbedUrl('/local/video.mp4')).toBe('/local/video.mp4');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,20 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+  try {
+    const parsedUrl = new URL(videoUrl, 'http://localhost');
+    if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch {
+    // Ignore invalid URLs
+  }
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `getYouTubeEmbedUrl` function returned unvalidated `videoUrl` directly into an iframe `src` attribute when the URL didn't match the YouTube regex, allowing potential XSS via `javascript:` or `data:` URIs provided in MDX frontmatter.
🎯 Impact: An attacker could execute arbitrary JavaScript within the context of the user's browser if they control the `videoUrl` field in MDX metadata.
🔧 Fix: Added protocol validation using the native `URL` constructor to ensure only `http:`, `https:`, or root-relative paths are allowed. Other protocols like `javascript:` and `data:` are blocked and replaced with `about:blank`.
✅ Verification: Added tests for `javascript:` and `data:` URIs to ensure they are blocked. Run `npm run test -- --run` to verify.

---
*PR created automatically by Jules for task [8161958178000547515](https://jules.google.com/task/8161958178000547515) started by @jreed91*