### PR TITLE
🛡️ Sentinel: [HIGH] Sanitize YouTube Embed URLs to Prevent XSS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+## 2025-03-03 - [Sanitize YouTube Embed URLs to Prevent XSS]
+**Vulnerability:** XSS vulnerability where `getYouTubeEmbedUrl` in `app/db/talks.ts` returned arbitrary user-supplied `videoUrl` directly if it didn't match the YouTube regex. These values were then used directly in `iframe` `src` attributes in `app/components/TalkLayout.tsx`, allowing XSS execution via `javascript:` URIs.
+**Learning:** `iframe` `src` attributes are susceptible to executing scripts when supplied with `javascript:` or `data:` URIs. Relying solely on a regex check without protocol validation for the fallback creates a bypass vector.
+**Prevention:** Validate protocols using `new URL(url, base)`. Return the URL only if the protocol is safe (e.g., `http:`, `https:`, or a valid root-relative path parsed against a base), and fallback to `about:blank` otherwise.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,17 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for javascript: URIs to prevent XSS', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl(' javascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('returns about:blank for data: URIs', () => {
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
+  });
+
+  it('returns the original URL unchanged for root-relative paths', () => {
+    expect(getYouTubeEmbedUrl('/local-video.mp4')).toBe('/local-video.mp4');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,23 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const url = new URL(videoUrl, 'http://localhost');
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore parsing errors
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** `getYouTubeEmbedUrl` in `app/db/talks.ts` used a fallback mechanism that returned arbitrary user-supplied `videoUrl` strings directly if they didn't match the YouTube regex. These values were subsequently used in `iframe` `src` attributes in `app/components/TalkLayout.tsx`. If an attacker provided a `javascript:` or `data:` URI, it would be executed when the iframe loaded, leading to a Cross-Site Scripting (XSS) vulnerability.
🎯 **Impact:** An attacker could execute arbitrary JavaScript within the context of the user's session if malicious content was embedded in the markdown file's metadata for a talk.
🔧 **Fix:** Added protocol validation using `new URL(url, 'http://localhost')`. Only URLs with `http:` or `https:` protocols (including valid root-relative paths when parsed against the base) are returned. Invalid or unsafe protocols (like `javascript:` or `data:`) safely fall back to `about:blank`.
✅ **Verification:** Added explicit unit tests in `app/db/talks.test.ts` to verify that `javascript:` and `data:` URIs are correctly neutralized and return `about:blank`. Ran `npx vitest run app/db/talks.test.ts` and all tests pass.

---
*PR created automatically by Jules for task [4359405506665175614](https://jules.google.com/task/4359405506665175614) started by @jreed91*