### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+## 2025-03-03 - [Fix Iframe XSS]
+**Vulnerability:** XSS vulnerability where user-provided or external URLs could be injected into `iframe` `src` attributes without protocol validation, allowing `javascript:` URIs.
+**Learning:** React does not natively sanitize `iframe` `src` attributes. Relying on simple regex or blindly trusting frontmatter URLs leaves the application open to XSS.
+**Prevention:** Always validate external URL protocols using the native `URL` constructor, ensuring only `http:` or `https:` are permitted, and fallback to `about:blank` or safe relative paths.

--- a/app/components/TalkCard.tsx
+++ b/app/components/TalkCard.tsx
@@ -1,10 +1,10 @@
-import { Talk } from 'app/db/talks';
-import Link from 'next/link';
-import { parseISO, format } from 'date-fns';
+import { Talk } from "app/db/talks";
+import Link from "next/link";
+import { parseISO, format } from "date-fns";
 
 export default function TalkCard({ talk }: { talk: Talk }) {
   return (
-    <Link href={`/talks/${talk.slug}`} className="w-full">
+    <Link href={`/talks/${encodeURIComponent(talk.slug)}`} className="w-full">
       <div className="w-full mb-8 transform hover:scale-[1.01] transition-all">
         <div className="flex flex-col justify-between md:flex-row">
           <h4 className="w-full mb-2 text-lg font-medium text-gray-900 md:text-xl dark:text-gray-100">
@@ -28,7 +28,7 @@ export default function TalkCard({ talk }: { talk: Talk }) {
           </div>
         </div>
         <div className="flex items-center gap-2 mb-2 text-sm text-gray-600 dark:text-gray-400">
-          <span>{format(parseISO(talk.metadata.date), 'MMMM dd, yyyy')}</span>
+          <span>{format(parseISO(talk.metadata.date), "MMMM dd, yyyy")}</span>
           {talk.metadata.event && (
             <>
               <span>•</span>
@@ -36,7 +36,9 @@ export default function TalkCard({ talk }: { talk: Talk }) {
             </>
           )}
         </div>
-        <p className="text-gray-600 dark:text-gray-400">{talk.metadata.summary}</p>
+        <p className="text-gray-600 dark:text-gray-400">
+          {talk.metadata.summary}
+        </p>
       </div>
     </Link>
   );

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -1,48 +1,62 @@
-import { describe, it, expect } from 'vitest';
-import { getYouTubeEmbedUrl } from './talks';
+import { describe, it, expect } from "vitest";
+import { getYouTubeEmbedUrl } from "./talks";
 
-describe('getYouTubeEmbedUrl', () => {
-  it('converts a standard youtube.com watch URL', () => {
-    const url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+describe("getYouTubeEmbedUrl", () => {
+  it("converts a standard youtube.com watch URL", () => {
+    const url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/dQw4w9WgXcQ'
+      "https://www.youtube.com/embed/dQw4w9WgXcQ",
     );
   });
 
-  it('converts a youtu.be short URL', () => {
-    const url = 'https://youtu.be/dQw4w9WgXcQ';
+  it("converts a youtu.be short URL", () => {
+    const url = "https://youtu.be/dQw4w9WgXcQ";
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/dQw4w9WgXcQ'
+      "https://www.youtube.com/embed/dQw4w9WgXcQ",
     );
   });
 
-  it('converts a youtube.com/embed URL', () => {
-    const url = 'https://www.youtube.com/embed/dQw4w9WgXcQ';
+  it("converts a youtube.com/embed URL", () => {
+    const url = "https://www.youtube.com/embed/dQw4w9WgXcQ";
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/dQw4w9WgXcQ'
+      "https://www.youtube.com/embed/dQw4w9WgXcQ",
     );
   });
 
-  it('converts a youtube.com/v/ URL', () => {
-    const url = 'https://www.youtube.com/v/dQw4w9WgXcQ';
+  it("converts a youtube.com/v/ URL", () => {
+    const url = "https://www.youtube.com/v/dQw4w9WgXcQ";
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/dQw4w9WgXcQ'
+      "https://www.youtube.com/embed/dQw4w9WgXcQ",
     );
   });
 
-  it('returns the original URL unchanged for non-YouTube URLs', () => {
-    const url = 'https://vimeo.com/123456789';
+  it("returns the original URL unchanged for non-YouTube URLs", () => {
+    const url = "https://vimeo.com/123456789";
     expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 
-  it('returns the original URL unchanged for empty string', () => {
-    expect(getYouTubeEmbedUrl('')).toBe('');
+  it("returns the original URL unchanged for empty string", () => {
+    expect(getYouTubeEmbedUrl("")).toBe("");
   });
 
-  it('handles video IDs with hyphens and underscores', () => {
-    const url = 'https://youtu.be/abc-def_123';
+  it("returns about:blank for javascript: URIs", () => {
+    expect(getYouTubeEmbedUrl("javascript:alert(1)")).toBe("about:blank");
+  });
+
+  it("returns about:blank for data: URIs", () => {
+    expect(getYouTubeEmbedUrl("data:text/html,<script>alert(1)</script>")).toBe(
+      "about:blank",
+    );
+  });
+
+  it("returns the original URL for root-relative paths", () => {
+    expect(getYouTubeEmbedUrl("/local/video.mp4")).toBe("/local/video.mp4");
+  });
+
+  it("handles video IDs with hyphens and underscores", () => {
+    const url = "https://youtu.be/abc-def_123";
     expect(getYouTubeEmbedUrl(url)).toBe(
-      'https://www.youtube.com/embed/abc-def_123'
+      "https://www.youtube.com/embed/abc-def_123",
     );
   });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from "fs";
+import path from "path";
 
 type TalkMetadata = {
   title: string;
@@ -20,14 +20,14 @@ function parseFrontmatter(fileContent: string) {
   let frontmatterRegex = /---\s*([\s\S]*?)\s*---/;
   let match = frontmatterRegex.exec(fileContent);
   let frontMatterBlock = match![1];
-  let content = fileContent.replace(frontmatterRegex, '').trim();
-  let frontMatterLines = frontMatterBlock.trim().split('\n');
+  let content = fileContent.replace(frontmatterRegex, "").trim();
+  let frontMatterLines = frontMatterBlock.trim().split("\n");
   let metadata: Partial<TalkMetadata> = {};
 
   frontMatterLines.forEach((line) => {
-    let [key, ...valueArr] = line.split(': ');
-    let value = valueArr.join(': ').trim();
-    value = value.replace(/^['"](.*)['"]$/, '$1'); // Remove quotes
+    let [key, ...valueArr] = line.split(": ");
+    let value = valueArr.join(": ").trim();
+    value = value.replace(/^['"](.*)['"]$/, "$1"); // Remove quotes
     metadata[key.trim() as keyof TalkMetadata] = value;
   });
 
@@ -35,11 +35,11 @@ function parseFrontmatter(fileContent: string) {
 }
 
 function getMDXFiles(dir: fs.PathLike) {
-  return fs.readdirSync(dir).filter((file) => path.extname(file) === '.mdx');
+  return fs.readdirSync(dir).filter((file) => path.extname(file) === ".mdx");
 }
 
 function readMDXFile(filePath: fs.PathOrFileDescriptor) {
-  let rawContent = fs.readFileSync(filePath, 'utf-8');
+  let rawContent = fs.readFileSync(filePath, "utf-8");
   return parseFrontmatter(rawContent);
 }
 
@@ -58,15 +58,27 @@ function getMDXData(dir: string): Talk[] {
 }
 
 export function getTalks(): Talk[] {
-  return getMDXData(path.join(process.cwd(), 'content', 'talks'));
+  return getMDXData(path.join(process.cwd(), "content", "talks"));
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return "";
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const parsed = new URL(videoUrl, "http://localhost");
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore error and fallthrough to fallback
+  }
+
+  return "about:blank";
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** User-provided or external URLs could be injected into `iframe` `src` attributes in MDX talks without strict protocol validation, allowing arbitrary script execution via `javascript:` or `data:` URIs.
🎯 **Impact:** An attacker could potentially inject malicious scripts into the frontend if they can influence the markdown content or if external metadata is compromised (Stored XSS).
🔧 **Fix:** Refactored `getYouTubeEmbedUrl` to explicitly validate the URL protocol using the native `URL` constructor, ensuring that only `http:` or `https:` are permitted, and gracefully falling back to `about:blank` otherwise. Added comprehensive unit tests for these payloads.
✅ **Verification:** Run `npm run test -- --run` to verify the new test cases in `app/db/talks.test.ts` successfully assert that unsafe payloads result in `about:blank`.

---
*PR created automatically by Jules for task [14190125102219257872](https://jules.google.com/task/14190125102219257872) started by @jreed91*