### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS in iframe src via getYouTubeEmbedUrl

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+## 2025-03-03 - [Fix iframe src XSS]
+**Vulnerability:** XSS vulnerability where user-provided external links from MDX frontmatter were directly assigned to iframe `src` attributes without URL protocol validation in `getYouTubeEmbedUrl`.
+**Learning:** React does not natively sanitize iframe `src` attributes. Attackers can provide `javascript:` or `data:` URIs in the frontmatter which execute arbitrary code when the iframe loads.
+**Prevention:** Always validate protocols of external URLs using the native `URL` constructor (e.g., `new URL(url, 'http://localhost')`) to ensure they are safe (`http:` or `https:`) before using them in iframe `src` attributes. Fall back to `about:blank` for unsafe protocols.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,14 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('returns about:blank for javascript: URLs to prevent XSS', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('returns about:blank for data: URLs to prevent XSS', () => {
+    const url = 'data:text/html,<h1>XSS</h1>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,20 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URLs
+  }
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: User-provided MDX frontmatter `videoUrl` used directly as iframe `src` without validating protocol, allowing `javascript:` or `data:` URI XSS.
🎯 Impact: An attacker who controls MDX frontmatter could execute arbitrary JavaScript in the context of the user's session when viewing a talk layout page.
🔧 Fix: Updated `getYouTubeEmbedUrl` to validate the provided URL protocol via the native `URL` constructor, falling back to `about:blank` for unsafe protocols.
✅ Verification: Verified that unsafe URLs correctly fall back to `about:blank` in tests, while safe `http`/`https` or empty URLs remain functional.

---
*PR created automatically by Jules for task [6863466876271652434](https://jules.google.com/task/6863466876271652434) started by @jreed91*