### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix XSS in Iframe src via talks]
+**Vulnerability:** XSS vulnerability where non-YouTube URLs passed to `getYouTubeEmbedUrl` were blindly returned and injected into an `iframe`'s `src` attribute. This allowed execution of arbitrary scripts via `javascript:` URIs.
+**Learning:** React does not natively sanitize the `src` attribute of an `iframe`. Always validate external URLs or user inputs injected into `iframe` `src` properties.
+**Prevention:** Use the native `URL` constructor (e.g. `new URL(url, 'http://localhost')`) to reliably check the `.protocol` property, ensuring it is `http:` or `https:` before rendering, and falling back to a safe default like `about:blank`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,16 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('sanitizes javascript: URIs', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('sanitizes data: URIs', () => {
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
+  });
+
+  it('allows local paths', () => {
+    expect(getYouTubeEmbedUrl('/local-video.mp4')).toBe('/local-video.mp4');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,20 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore error
+  }
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: XSS vulnerability where non-YouTube URLs passed to `getYouTubeEmbedUrl` were unvalidated, allowing `javascript:` or `data:` URIs to be injected into an `iframe`'s `src` attribute.
🎯 Impact: Attackers could execute arbitrary scripts if they could influence the video URL metadata.
🔧 Fix: Used the native `URL` constructor to enforce safe protocols (`http:` or `https:`) and safely allowed root-relative paths, returning `about:blank` for malicious URIs.
✅ Verification: Ensure tests pass and the `src` attribute handles unsafe payloads properly.

---
*PR created automatically by Jules for task [18125316747675719282](https://jules.google.com/task/18125316747675719282) started by @jreed91*