### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS via URL missing proper protocol validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2024-05-24 - [Fix Stored XSS via URL missing proper protocol validation]
+**Vulnerability:** XSS/SSRF via unsanitized or poorly sanitized URL parameters in YouTube embed logic.
+**Learning:** Returning unvalidated input (e.g. `javascript:alert(1)`) into an `iframe src` allows for XSS when the fallback is used.
+**Prevention:** Validate protocols using the `new URL()` API and only allow `http:` or `https:`, falling back safely.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -35,7 +35,7 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 
-  it('returns the original URL unchanged for empty string', () => {
+  it('returns empty string for empty string', () => {
     expect(getYouTubeEmbedUrl('')).toBe('');
   });
 
@@ -44,5 +44,15 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl(url)).toBe(
       'https://www.youtube.com/embed/abc-def_123'
     );
+  });
+
+  it('prevents javascript: URLs', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('prevents data: URLs', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
   });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,23 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
+
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
+
+  try {
+    const url = new URL(videoUrl, 'http://localhost');
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return 'about:blank';
+    }
+  } catch (e) {
+    return 'about:blank';
+  }
+
   return videoUrl;
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: XSS via unvalidated URL protocols in getYouTubeEmbedUrl fallback.
🎯 Impact: Attackers could inject `javascript:` or `data:` URIs via the videoUrl field in markdown metadata, resulting in arbitrary JavaScript execution when the iframe is rendered.
🔧 Fix: Validated URL protocol using `new URL()` and restricted allowed protocols to `http:` and `https:`, falling back to `about:blank`.
✅ Verification: Ran `npm run test -- --run` with new tests checking `javascript:` and `data:` URLs.

---
*PR created automatically by Jules for task [16065584932629073398](https://jules.google.com/task/16065584932629073398) started by @jreed91*