### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe src attribute

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+## 2025-03-04 - [Fix XSS in iframe src]
+**Vulnerability:** XSS vulnerability where user-provided or markdown-sourced `videoUrl` was injected directly into an `iframe` `src` attribute without protocol validation, allowing `javascript:` URIs.
+**Learning:** React does not natively sanitize the `src` attribute of `iframe` elements. Any data source (including MDX frontmatter) that populates an `iframe` `src` could trigger script execution if it contains a `javascript:` or `data:` protocol.
+**Prevention:** Always validate protocols of external URLs using the native `URL` constructor (e.g., `new URL(url, 'http://localhost')`) before injecting them into `iframe` `src` or `a` `href` tags.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,19 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('sanitizes unsafe javascript: URLs to about:blank', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('sanitizes unsafe data: URLs to about:blank', () => {
+    const url = 'data:text/html,<script>alert(1)</script>';
+    expect(getYouTubeEmbedUrl(url)).toBe('about:blank');
+  });
+
+  it('allows local relative paths', () => {
+    const url = '/videos/local.mp4';
+    expect(getYouTubeEmbedUrl(url)).toBe(url);
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,17 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  if (!videoUrl) return videoUrl;
+
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // ignore parsing errors
+  }
+
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: User-provided or markdown-sourced `videoUrl` was injected directly into an `iframe` `src` attribute without protocol validation, allowing `javascript:` URIs.
🎯 Impact: A malicious author could inject `javascript:alert(1)` in the `videoUrl` frontmatter to execute arbitrary JavaScript on the victim's browser when rendering the talk layout.
🔧 Fix: Added protocol validation using `new URL()` in `getYouTubeEmbedUrl` to enforce `http:` or `https:`, falling back to `about:blank`.
✅ Verification: Tests passing, including new cases verifying `javascript:` and `data:` URLs are sanitized.

---
*PR created automatically by Jules for task [8325504744880468123](https://jules.google.com/task/8325504744880468123) started by @jreed91*