### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in Talk video embeds

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe src XSS in TalkLayout]
+**Vulnerability:** XSS vulnerability in `app/components/TalkLayout.tsx` where an unfiltered `talk.metadata.videoUrl` fallback from `getYouTubeEmbedUrl` could render `javascript:` or `data:` URIs directly into an `<iframe src="...">` attribute.
+**Learning:** Next.js and React do not natively sanitize strings passed to `iframe` `src` attributes. A malicious payload in MDX frontmatter could execute arbitrary code in the user's browser.
+**Prevention:** Always validate protocols of external URLs using the native `URL` constructor (e.g., ensuring `http:` or `https:`) before injection to prevent XSS vulnerabilities from `javascript:` or `data:` URIs.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -30,7 +30,7 @@ describe('getYouTubeEmbedUrl', () => {
     );
   });
 
-  it('returns the original URL unchanged for non-YouTube URLs', () => {
+  it('returns the original URL unchanged for safe non-YouTube URLs', () => {
     const url = 'https://vimeo.com/123456789';
     expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
@@ -44,5 +44,13 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl(url)).toBe(
       'https://www.youtube.com/embed/abc-def_123'
     );
+  });
+
+  it('prevents XSS by rejecting javascript: URIs', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('');
+  });
+
+  it('prevents XSS by rejecting data: URIs', () => {
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('');
   });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,17 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  if (!videoUrl) return '';
+
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URLs
+  }
+
+  return '';
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unfiltered fallback video URLs in MDX frontmatter were returned by `getYouTubeEmbedUrl` without validating the URL protocol. These strings are rendered directly into the `<iframe src={...}>` attribute in `TalkLayout.tsx`, which meant `javascript:` and `data:` URIs could be successfully evaluated by the browser.
🎯 **Impact:** XSS execution in the browser if a malicious markdown content payload contains an unsafe URI.
🔧 **Fix:** Changed `getYouTubeEmbedUrl` to validate fallback URLs with the native `URL` constructor, and enforce `http:` or `https:` protocols, otherwise returning an empty string.
✅ **Verification:** Added tests for XSS payloads which successfully catch the empty string responses, verified with `npx vitest --run app/db/talks.test.ts`. Recorded learning in Sentinel journal.

---
*PR created automatically by Jules for task [8213157660965322208](https://jules.google.com/task/8213157660965322208) started by @jreed91*