### PR TITLE
🛡️ Sentinel: [HIGH] Sanitize slugs in URLs to prevent XSS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2026-08-15 - [XSS via Missing URL Encoding in Link Hrefs]
+**Vulnerability:** File-derived variables like `talk.slug` and `blog.slug` were directly interpolated into Next.js `<Link href={...}>` and external URLs without URL encoding. This could allow for Stored Cross-Site Scripting (XSS) if a malicious slug contains characters like quotes or brackets.
+**Learning:** Always sanitize user-controllable or file-derived variables (like slugs) using `encodeURIComponent()` when constructing URLs or paths, as these variables can bypass normal text sanitization if placed within URL contexts.
+**Prevention:** Use `encodeURIComponent(slug)` whenever dynamically creating `href` or `src` attributes with variables. Avoid blindly applying it to variables meant to hold full URLs or paths with slashes.

--- a/app/components/BlogLayout.tsx
+++ b/app/components/BlogLayout.tsx
@@ -7,10 +7,10 @@ import { CustomMDX } from "./Mdx";
 import TableOfContents from "./TableOfContents";
 
 const editUrl = (slug: string) =>
-  `https://github.com/jreed91/jacobreed.dev/edit/master/data/blog/${slug}.mdx`;
+  `https://github.com/jreed91/jacobreed.dev/edit/master/data/blog/${encodeURIComponent(slug)}.mdx`;
 const discussUrl = (slug: string) =>
   `https://mobile.twitter.com/search?q=${encodeURIComponent(
-    `https://jacobreed.dev/blog/${slug}`
+    `https://jacobreed.dev/blog/${encodeURIComponent(slug)}`
   )}`;
 
 export default function BlogLayout({

--- a/app/components/BlogPost.tsx
+++ b/app/components/BlogPost.tsx
@@ -5,7 +5,7 @@ import { parseISO, format } from 'date-fns';
 
 export default function BlogPost ({ blog }: { blog: Blog}) {
   return (
-    <Link href={`/blog/${blog.slug}`} className="w-full ">
+    <Link href={`/blog/${encodeURIComponent(blog.slug)}`} className="w-full ">
         <div className="w-full mb-8 transform hover:scale-[1.01] transition-all">
           <div className="flex flex-col justify-between md:flex-row">
             <h4 className="w-full mb-2 text-lg font-medium text-gray-900 md:text-xl dark:text-gray-100">

--- a/app/components/BlogPostCard.tsx
+++ b/app/components/BlogPostCard.tsx
@@ -5,7 +5,7 @@ import { parseISO, format } from 'date-fns';
 export default function BlogPostCard({ title, slug, summary, date, readingTime }: {title: string, slug: string, summary: string, date: string, readingTime: string}) {
 
   return (
-    <Link href={`/blog/${slug}`}  className={cn(
+    <Link href={`/blog/${encodeURIComponent(slug)}`}  className={cn(
       'transform hover:scale-[1.01] transition-all',
       'rounded-xl w-full md:w-1/3 bg-gradient-to-r p-1',
       'bg-gray-200'

--- a/app/components/TalkCard.tsx
+++ b/app/components/TalkCard.tsx
@@ -4,7 +4,7 @@ import { parseISO, format } from 'date-fns';
 
 export default function TalkCard({ talk }: { talk: Talk }) {
   return (
-    <Link href={`/talks/${talk.slug}`} className="w-full">
+    <Link href={`/talks/${encodeURIComponent(talk.slug)}`} className="w-full">
       <div className="w-full mb-8 transform hover:scale-[1.01] transition-all">
         <div className="flex flex-col justify-between md:flex-row">
           <h4 className="w-full mb-2 text-lg font-medium text-gray-900 md:text-xl dark:text-gray-100">


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Slugs derived from files were directly interpolated into Link hrefs and external URLs without sanitization.
🎯 Impact: Potential Stored Cross-Site Scripting (XSS) if a slug contains malicious characters.
🔧 Fix: Used `encodeURIComponent()` to sanitize slugs in `Link` components and generated URLs.
✅ Verification: Run `npm run test -- --run` and verify `Link` components in the application still function correctly.

---
*PR created automatically by Jules for task [15807809358915139463](https://jules.google.com/task/15807809358915139463) started by @jreed91*