### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix iframe XSS vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix Iframe XSS]
+**Vulnerability:** XSS vulnerability in `TalkLayout.tsx` where an untrusted markdown frontmatter value (`videoUrl`) was directly bound to an `iframe`'s `src` attribute.
+**Learning:** React and Next.js do not natively sanitize strings passed to `iframe` `src` attributes, making them vulnerable to `javascript:` or `data:` URIs.
+**Prevention:** Always validate protocols of external URLs using the native `URL` constructor (e.g., ensuring `http:` or `https:`) before using them in `iframe` `src` or `a` `href` attributes to prevent XSS.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -39,6 +39,11 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl('')).toBe('');
   });
 
+  it('filters out unsafe protocols like javascript:', () => {
+    const url = 'javascript:alert(1)';
+    expect(getYouTubeEmbedUrl(url)).toBe('');
+  });
+
   it('handles video IDs with hyphens and underscores', () => {
     const url = 'https://youtu.be/abc-def_123';
     expect(getYouTubeEmbedUrl(url)).toBe(

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -62,11 +62,21 @@ export function getTalks(): Talk[] {
 }
 
 export function getYouTubeEmbedUrl(videoUrl: string): string {
+  if (!videoUrl) return '';
   const youtubeRegex =
     /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([a-zA-Z0-9_-]{11})/;
   const match = youtubeRegex.exec(videoUrl);
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URLs
+  }
+  return '';
 }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unsanitized user input from MDX frontmatter `videoUrl` could be passed directly to `iframe` `src`, potentially executing `javascript:` or `data:` URIs.
🎯 **Impact:** XSS execution on page load if malicious content is authored or injected into the content repository.
🔧 **Fix:** Validated URL protocols for `videoUrl` in `getYouTubeEmbedUrl` ensuring only `http:` or `https:` or well-formed youtube domains are processed, falling back to a safe empty string for unknown protocols.
✅ **Verification:** Verified by unit tests rejecting `javascript:alert(1)` URLs and passing normal YouTube embeds.

---
*PR created automatically by Jules for task [17560105698303789748](https://jules.google.com/task/17560105698303789748) started by @jreed91*