### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe src attribute

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix iframe XSS via javascript: URLs]
+**Vulnerability:** XSS vulnerability where unvalidated `videoUrl` values from MDX frontmatter are passed directly to `iframe` `src` attributes in `app/components/TalkLayout.tsx` via `getYouTubeEmbedUrl`.
+**Learning:** React does not natively sanitize strings passed to `iframe` `src` attributes. External URLs or fallback paths must have their protocols strictly validated to prevent execution of `javascript:` or `data:` URIs.
+**Prevention:** Always validate URL protocols using the native `URL` constructor (e.g., `new URL(url, 'http://localhost')`) before injecting them into `iframe` `src` attributes or user-provided links to ensure they are safe protocols like `http:` or `https:`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -39,6 +39,11 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl('')).toBe('');
   });
 
+  it('strips javascript: and data: URLs to prevent XSS', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('');
+    expect(getYouTubeEmbedUrl('data:text/html,<script>alert(1)</script>')).toBe('');
+  });
+
   it('handles video IDs with hyphens and underscores', () => {
     const url = 'https://youtu.be/abc-def_123';
     expect(getYouTubeEmbedUrl(url)).toBe(

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,16 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  if (!videoUrl) return '';
+
+  try {
+    const url = new URL(videoUrl, 'http://localhost');
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return '';
+    }
+    return videoUrl;
+  } catch {
+    return '';
+  }
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `getYouTubeEmbedUrl` function returned unvalidated fallback URLs which were used directly in an `iframe` `src` attribute. This allowed XSS if an attacker controlled the `videoUrl` frontmatter and used a `javascript:` or `data:` URI.
🎯 Impact: An attacker could execute arbitrary JavaScript in the context of the user's session if a malicious talk frontmatter was rendered.
🔧 Fix: Validated the protocol of fallback URLs using the native `URL` constructor, ensuring only `http:` or `https:` protocols are returned, falling back to an empty string.
✅ Verification: New unit tests verify that `javascript:` and `data:` URIs are safely stripped and return an empty string. The Sentinel journal was also updated.

---
*PR created automatically by Jules for task [9601436446573652756](https://jules.google.com/task/9601436446573652756) started by @jreed91*