### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in iframe src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+
+## 2025-03-03 - [Fix Iframe XSS]
+**Vulnerability:** XSS vulnerability where untrusted URLs from MDX frontmatter (`videoUrl`) were injected directly into an `iframe` `src` attribute.
+**Learning:** React/Next.js do not natively sanitize strings passed to `iframe` `src` attributes. A malicious user could provide a `javascript:` or `data:` URI which executes arbitrary code.
+**Prevention:** Always validate protocols of external URLs using the native `URL` constructor (e.g. `new URL(url, 'http://localhost')`) before injection to ensure they are `http:` or `https:`.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -35,6 +35,12 @@ describe('getYouTubeEmbedUrl', () => {
     expect(getYouTubeEmbedUrl(url)).toBe(url);
   });
 
+  it('sanitizes unsafe protocols', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('data:text/html,a')).toBe('about:blank');
+    expect(getYouTubeEmbedUrl('   javascript:alert(2)')).toBe('about:blank');
+  });
+
   it('returns the original URL unchanged for empty string', () => {
     expect(getYouTubeEmbedUrl('')).toBe('');
   });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,13 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Fallback for invalid URLs
+  }
+  return 'about:blank';
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unvalidated fallback `videoUrl` values derived from MDX frontmatter were injected directly into an `iframe` `src` attribute. This made the attribute susceptible to XSS via unsafe URIs.
🎯 **Impact:** An attacker or malicious user editing the MDX could execute arbitrary scripts by providing malicious `javascript:` or `data:` URIs in the frontmatter.
🔧 **Fix:** Implemented strict protocol validation for fallback video URLs using the native WHATWG `URL` constructor. The function now ensures that only `http:` or `https:` protocols are accepted, securely falling back to `about:blank` for dangerous protocols.
✅ **Verification:** Added comprehensive test coverage in `app/db/talks.test.ts` to ensure that `javascript:` and `data:` URIs are neutralized effectively, and confirmed tests passed.

---
*PR created automatically by Jules for task [12472202163481582345](https://jules.google.com/task/12472202163481582345) started by @jreed91*