### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in getYouTubeEmbedUrl

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** XSS vulnerability where standard `JSON.stringify` was used in `dangerouslySetInnerHTML` for JSON-LD `<script type="application/ld+json">` tags in `app/blog/[slug]/page.tsx`.
 **Learning:** React/Next.js assumes strings inside `dangerouslySetInnerHTML` are safe. Using `JSON.stringify` does not escape `<` or `>` characters, allowing attackers to close the script tag early with `</script>` and execute arbitrary code if malicious content gets into the metadata.
 **Prevention:** Always use a utility like `safeJsonStringify` which replaces `<` with `\u003c`, `>` with `\u003e`, and `&` with `\u0026` before injecting JSON into `<script>` tags.
+## 2023-10-25 - [Fix XSS in getYouTubeEmbedUrl]
+**Vulnerability:** XSS vulnerability where `getYouTubeEmbedUrl` would return malicious `javascript:` or `data:` URIs which are then rendered into an `iframe src` attribute in `TalkLayout`.
+**Learning:** React does not natively sanitize strings passed to `iframe src` attributes. Always validate protocols of external URLs using the native `URL` constructor before injection.
+**Prevention:** Explicitly check the `.protocol` property of the parsed URL to ensure it is `http:` or `https:` and safely fall back to an empty string.

--- a/app/db/talks.test.ts
+++ b/app/db/talks.test.ts
@@ -45,4 +45,9 @@ describe('getYouTubeEmbedUrl', () => {
       'https://www.youtube.com/embed/abc-def_123'
     );
   });
+
+  it('rejects unsafe protocols like javascript: and data:', () => {
+    expect(getYouTubeEmbedUrl('javascript:alert(1)')).toBe('');
+    expect(getYouTubeEmbedUrl('data:text/html,<html>')).toBe('');
+  });
 });

--- a/app/db/talks.ts
+++ b/app/db/talks.ts
@@ -68,5 +68,15 @@ export function getYouTubeEmbedUrl(videoUrl: string): string {
   if (match) {
     return `https://www.youtube.com/embed/${match[1]}`;
   }
-  return videoUrl;
+
+  try {
+    const parsed = new URL(videoUrl, 'http://localhost');
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return videoUrl;
+    }
+  } catch (e) {
+    // Ignore invalid URLs
+  }
+
+  return '';
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `getYouTubeEmbedUrl` allows malicious protocols like `javascript:` and `data:` which are directly set in an `iframe src`.
🎯 Impact: Attackers can execute arbitrary JavaScript in the context of the domain via Cross-Site Scripting (XSS).
🔧 Fix: Validated the protocol of the non-YouTube URLs using the `URL` constructor and restricted it to `http:` and `https:`.
✅ Verification: Ensure the test suite passes and that unsafe protocols resolve to an empty string.

---
*PR created automatically by Jules for task [18049681262955427585](https://jules.google.com/task/18049681262955427585) started by @jreed91*